### PR TITLE
Make strtonum consistent with curlx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
+/CMakeCache.txt
+/CMakeFiles/
+/CTestTestfile.cmake
+/Makefile
 /argh.h
+/cmake_install.cmake
+/example_client
 /json.hpp
+/libndt.a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1.0)
-project(libndt LANGUAGES CXX)
+project(libndt LANGUAGES C CXX)
 
 # Download header only dependencies
 
@@ -74,6 +74,8 @@ endif()
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
 
 if("${UNIX}" OR "${MINGW}")
   set(LIBNDT_FLAGS "-Wall -Wextra -Werror")
@@ -98,7 +100,8 @@ add_library(
   curlx.hpp
   libndt.cpp
   libndt.hpp
-  strtonum.c.h
+  strtonum.c
+  strtonum.h
 )
 target_include_directories(
   ndt PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}

--- a/libndt.cpp
+++ b/libndt.cpp
@@ -20,15 +20,9 @@
 #include <random>
 #include <sstream>
 
-#include "json.hpp"
-
-#ifndef HAVE_STRTONUM
-#include "strtonum.c.h" // Include inline replacement
-#endif
-
-#ifdef HAVE_CURL
 #include "curlx.hpp"
-#endif
+#include "json.hpp"
+#include "strtonum.h"
 
 // Utils with C linkage
 

--- a/libndt.hpp
+++ b/libndt.hpp
@@ -26,7 +26,7 @@ namespace libndt {
 
 constexpr uint64_t api_major = 0;
 constexpr uint64_t api_minor = 13;
-constexpr uint64_t api_patch = 0;
+constexpr uint64_t api_patch = 1;
 
 constexpr uint8_t nettest_middlebox = 1 << 0;
 constexpr uint8_t nettest_upload = 1 << 1;

--- a/strtonum.c
+++ b/strtonum.c
@@ -1,5 +1,4 @@
-#ifndef MEASUREMENT_KIT_LIBNDT_STRTONUM_C_H
-#define MEASUREMENT_KIT_LIBNDT_STRTONUM_C_H
+#ifndef HAVE_STRTONUM
 /*	$OpenBSD: strtonum.c,v 1.8 2015/09/13 08:31:48 guenther Exp $	*/
 
 /*
@@ -23,11 +22,13 @@
 #include <limits.h>
 #include <stdlib.h>
 
+#include "strtonum.h"
+
 #define	INVALID		1
 #define	TOOSMALL	2
 #define	TOOLARGE	3
 
-static long long
+long long
 strtonum(const char *numstr, long long minval, long long maxval,
     const char **errstrp)
 {
@@ -66,4 +67,4 @@ strtonum(const char *numstr, long long minval, long long maxval,
 	return (ll);
 }
 /*DEF_WEAK(strtonum);*/
-#endif
+#endif /* !HAVE_STRTONUM */

--- a/strtonum.h
+++ b/strtonum.h
@@ -1,0 +1,22 @@
+/* Part of Measurement Kit <https://measurement-kit.github.io/>.
+   Measurement Kit is free software under the BSD license. See AUTHORS
+   and LICENSE for more information on the copying conditions. */
+#ifndef STRTONUM_H
+#define STRTONUM_H
+
+#ifdef HAVE_STRTONUM
+#include <stdlib.h>
+#else
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+long long
+strtonum(const char *numstr, long long minval, long long maxval,
+    const char **errstrp);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* HAVE_STRTONUM */
+#endif /* STRTONUM_H */


### PR DESCRIPTION
Now they are both compiled. Before strtonum was included
inline. Not a bit deal. Just consistency.