### PR TITLE
libndt.hpp: really include what we use

### DIFF
--- a/libndt.hpp
+++ b/libndt.hpp
@@ -26,11 +26,13 @@
 
 #ifndef _WIN32
 #include <sys/select.h>
+#include <sys/socket.h>
 #else
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #endif
 
+#include <netdb.h>
 #include <stddef.h>
 #include <stdint.h>  // IWYU pragma: export
 
@@ -38,10 +40,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-
-struct addrinfo;
-struct sockaddr;
-struct timeval;
 
 /// Contains measurement-kit code.
 namespace measurement_kit {

--- a/libndt.hpp
+++ b/libndt.hpp
@@ -32,7 +32,9 @@
 #include <ws2tcpip.h>
 #endif
 
+#ifndef _WIN32
 #include <netdb.h>
+#endif
 #include <stddef.h>
 #include <stdint.h>  // IWYU pragma: export
 


### PR DESCRIPTION
Sometimes `iwyu` suggests to forward declare some standard
structs but really it's better to pull includes.

Recommended by @pboothe in a conversation some time ago.