### PR TITLE
libndt: clarify we're dealing with system errors

### DIFF
--- a/libndt.hpp
+++ b/libndt.hpp
@@ -334,8 +334,8 @@ class Client {
 
   // Dependencies (libc)
 
-  virtual int get_last_error() noexcept;
-  virtual void set_last_error(int err) noexcept;
+  virtual int get_last_system_error() noexcept;
+  virtual void set_last_system_error(int err) noexcept;
 
   virtual int getaddrinfo(const char *domain, const char *port,
                           const addrinfo *hints, addrinfo **res) noexcept;


### PR DESCRIPTION
We're going to integrate OpenSSL soon. With OpenSSL we will have
different kind of errors. So better to have functions that are
named to clarify that they deal with system errors.