### PR TITLE
Refactor cURL to print directly errors

### DIFF
--- a/curlx.hpp
+++ b/curlx.hpp
@@ -12,6 +12,8 @@
 
 #include <curl/curl.h>
 
+#include "libndt.hpp"
+
 namespace measurement_kit {
 namespace libndt {
 
@@ -24,14 +26,14 @@ class Curl {
  public:
   // Top-level API
 
-  Curl() noexcept;
+  explicit Curl(Client *client) noexcept;
 
   bool method_get_maybe_socks5(const std::string &proxy_port,
                                const std::string &url, long timeout,
-                               std::string *body, std::string *err) noexcept;
+                               std::string *body) noexcept;
 
-  bool method_get(const std::string &url, long timeout, std::string *body,
-                  std::string *err) noexcept;
+  bool method_get(const std::string &url, long timeout,
+                  std::string *body) noexcept;
 
   // Mid-level API
 
@@ -58,6 +60,7 @@ class Curl {
 
  private:
   std::unique_ptr<CURL, CurlDeleter> handle_;
+  Client *client_ = nullptr;
 };
 
 }  // namespace libndt

--- a/curlx_test.cpp
+++ b/curlx_test.cpp
@@ -19,10 +19,10 @@ class FailInit : public libndt::Curl {
 };
 
 TEST_CASE("Curl::method_get_maybe_socks5() deals with Curl::init() failure") {
-  FailInit curl;
+  libndt::Client client;
+  FailInit curl{&client};
   std::string body;
-  std::string err;
-  REQUIRE(!curl.method_get_maybe_socks5("", "http://x.org", 1, &body, &err));
+  REQUIRE(!curl.method_get_maybe_socks5("", "http://x.org", 1, &body));
 }
 
 class FailSetoptProxy : public libndt::Curl {
@@ -35,34 +35,27 @@ class FailSetoptProxy : public libndt::Curl {
 
 TEST_CASE(
     "Curl::method_get_maybe_socks5() deals with Curl::setopt_proxy() failure") {
-  FailSetoptProxy curl;
+  libndt::Client client;
+  FailSetoptProxy curl{&client};
   std::string body;
-  std::string err;
   REQUIRE(
-      !curl.method_get_maybe_socks5("9050", "http://x.org", 1, &body, &err));
-  REQUIRE(err == "cannot set proxy");
+      !curl.method_get_maybe_socks5("9050", "http://x.org", 1, &body));
 }
 
 // Curl::method_get() tests
 // ------------------------
 
 TEST_CASE("Curl::method_get() deals with null body") {
-  libndt::Curl curl;
-  std::string err;
-  REQUIRE(curl.method_get("http://x.org", 1, nullptr, &err) == false);
-}
-
-TEST_CASE("Curl::method_get() deals with null err") {
-  libndt::Curl curl;
-  std::string body;
-  REQUIRE(curl.method_get("http://x.org", 1, &body, nullptr) == false);
+  libndt::Client client;
+  libndt::Curl curl{&client};
+  REQUIRE(curl.method_get("http://x.org", 1, nullptr) == false);
 }
 
 TEST_CASE("Curl::method_get() deals with Curl::init() failure") {
-  FailInit curl;
+  libndt::Client client;
+  FailInit curl{&client};
   std::string body;
-  std::string err;
-  REQUIRE(curl.method_get("http://x.org", 1, &body, &err) == false);
+  REQUIRE(curl.method_get("http://x.org", 1, &body) == false);
 }
 
 class FailSetoptUrl : public libndt::Curl {
@@ -74,10 +67,10 @@ class FailSetoptUrl : public libndt::Curl {
 };
 
 TEST_CASE("Curl::method_get() deals with Curl::setopt_url() failure") {
-  FailSetoptUrl curl;
+  libndt::Client client;
+  FailSetoptUrl curl{&client};
   std::string body;
-  std::string err;
-  REQUIRE(curl.method_get("http://x.org", 1, &body, &err) == false);
+  REQUIRE(curl.method_get("http://x.org", 1, &body) == false);
 }
 
 class FailSetoptWritefunction : public libndt::Curl {
@@ -91,10 +84,10 @@ class FailSetoptWritefunction : public libndt::Curl {
 
 TEST_CASE(  //
     "Curl::method_get() deals with Curl::setopt_writefunction() failure") {
-  FailSetoptWritefunction curl;
+  libndt::Client client;
+  FailSetoptWritefunction curl{&client};
   std::string body;
-  std::string err;
-  REQUIRE(curl.method_get("http://x.org", 1, &body, &err) == false);
+  REQUIRE(curl.method_get("http://x.org", 1, &body) == false);
 }
 
 class FailSetoptWritedata : public libndt::Curl {
@@ -106,10 +99,10 @@ class FailSetoptWritedata : public libndt::Curl {
 };
 
 TEST_CASE("Curl::method_get() deals with Curl::setopt_writedata() failure") {
-  FailSetoptWritedata curl;
+  libndt::Client client;
+  FailSetoptWritedata curl{&client};
   std::string body;
-  std::string err;
-  REQUIRE(curl.method_get("http://x.org", 1, &body, &err) == false);
+  REQUIRE(curl.method_get("http://x.org", 1, &body) == false);
 }
 
 class FailSetoptTimeout : public libndt::Curl {
@@ -121,10 +114,10 @@ class FailSetoptTimeout : public libndt::Curl {
 };
 
 TEST_CASE("Curl::method_get() deals with Curl::setopt_timeout() failure") {
-  FailSetoptTimeout curl;
+  libndt::Client client;
+  FailSetoptTimeout curl{&client};
   std::string body;
-  std::string err;
-  REQUIRE(curl.method_get("http://x.org", 1, &body, &err) == false);
+  REQUIRE(curl.method_get("http://x.org", 1, &body) == false);
 }
 
 class FailPerform : public libndt::Curl {
@@ -134,10 +127,10 @@ class FailPerform : public libndt::Curl {
 };
 
 TEST_CASE("Curl::method_get() deals with Curl::perform() failure") {
-  FailPerform curl;
+  libndt::Client client;
+  FailPerform curl{&client};
   std::string body;
-  std::string err;
-  REQUIRE(curl.method_get("http://x.org", 1, &body, &err) == false);
+  REQUIRE(curl.method_get("http://x.org", 1, &body) == false);
 }
 
 // Curl::init() tests
@@ -150,12 +143,14 @@ class FailEasyInit : public libndt::Curl {
 };
 
 TEST_CASE("Curl::init() deals with curl_easy_init() failure") {
-  FailEasyInit curl;
+  libndt::Client client;
+  FailEasyInit curl{&client};
   REQUIRE(curl.init() == false);
 }
 
 TEST_CASE("Curl::init() is idempotent") {
-  libndt::Curl curl;
+  libndt::Client client;
+  libndt::Curl curl{&client};
   REQUIRE(curl.init() == true);
   REQUIRE(curl.init() == true);
 }
@@ -164,7 +159,8 @@ TEST_CASE("Curl::init() is idempotent") {
 // --------------------------
 
 TEST_CASE("Curl::setopt_proxy() works") {
-  libndt::Curl curl;
+  libndt::Client client;
+  libndt::Curl curl{&client};
   REQUIRE(curl.init() == true);
   REQUIRE(curl.setopt_proxy("socks5h://127.0.0.1:9050") == CURLE_OK);
 }

--- a/libndt.cpp
+++ b/libndt.cpp
@@ -1371,14 +1371,16 @@ bool Client::resolve(const std::string &hostname,
 
 // Dependencies (curl)
 
+uint64_t Client::get_verbosity() const noexcept {
+  return impl->settings.verbosity;
+}
+
 bool Client::query_mlabns_curl(const std::string &url, long timeout,
                                std::string *body) noexcept {
 #ifdef HAVE_CURL
-  std::string err = "";
-  Curl curl;
+  Curl curl{this};
   if (!curl.method_get_maybe_socks5(  //
-          impl->settings.socks5h_port, url, timeout, body, &err)) {
-    EMIT_WARNING("cannot query mlabns: " << err);
+          impl->settings.socks5h_port, url, timeout, body)) {
     return false;
   }
   return true;

--- a/libndt.hpp
+++ b/libndt.hpp
@@ -329,6 +329,8 @@ class Client {
 
   // Dependencies (cURL)
 
+  uint64_t get_verbosity() const noexcept;
+
   virtual bool query_mlabns_curl(const std::string &url, long timeout,
                                  std::string *body) noexcept;
 


### PR DESCRIPTION
Rather than returning an error from Curl to Client, pass a pointer
to Client to Curl so that it can print log messages directly.