### PR TITLE
Make code nonblocking

### DIFF
--- a/libndt.hpp
+++ b/libndt.hpp
@@ -330,10 +330,16 @@ class Client {
   virtual Err netx_recv(Socket fd, void *base, Size count,
                         Size *actual) noexcept;
 
+  virtual Err netx_recv_nonblocking(Socket fd, void *base, Size count,
+                                    Size *actual) noexcept;
+
   virtual Err netx_recvn(Socket fd, void *base, Size count) noexcept;
 
   virtual Err netx_send(Socket fd, const void *base, Size count,
                         Size *actual) noexcept;
+
+  virtual Err netx_send_nonblocking(Socket fd, const void *base, Size count,
+                                    Size *actual) noexcept;
 
   virtual Err netx_sendn(Socket fd, const void *base, Size count) noexcept;
 

--- a/libndt.hpp
+++ b/libndt.hpp
@@ -153,9 +153,8 @@ class Settings {
   /// hostname, mlab-ns won't be used.
   std::string mlabns_url = "https://mlab-ns.appspot.com/ndt";
 
-  /// cURL timeout used when querying mlab-ns. If you specify an explicit
-  /// hostname, mlab-ns won't be used.
-  long curl_timeout = 3 /* seconds */;
+  /// Timeout used for I/O operations (including cURL operations).
+  long timeout = 3 /* seconds */;
 
   /// Host name of the NDT server to use. If this is left blank (the default),
   /// we will use mlab-ns to discover a nearby server.

--- a/libndt.hpp
+++ b/libndt.hpp
@@ -326,6 +326,8 @@ class Client {
   virtual Err netx_dial(const std::string &hostname, const std::string &port,
                         Socket *sock) noexcept;
 
+  virtual Err netx_connect(Socket fd, const sockaddr *sa, SockLen n) noexcept;
+
   virtual Err netx_recv(Socket fd, void *base, Size count,
                         Size *actual) noexcept;
 
@@ -339,7 +341,7 @@ class Client {
   virtual Err netx_resolve(const std::string &hostname,
                            std::vector<std::string> *addrs) noexcept;
 
-  virtual Err netx_setnonblocking(Socket fd) noexcept;
+  virtual Err netx_setnonblocking(Socket fd, bool enable) noexcept;
 
   // Dependencies (cURL)
 
@@ -379,6 +381,8 @@ class Client {
   virtual int fcntl2(Socket s, int cmd) noexcept;
   virtual int fcntl3i(Socket s, int cmd, int arg) noexcept;
 #endif
+
+  virtual int getpeername(Socket s, sockaddr *sa, SockLen *n) noexcept;
 
  private:
   class Impl;

--- a/libndt_test.cpp
+++ b/libndt_test.cpp
@@ -2473,7 +2473,8 @@ class FailIoctlsocket : public libndt::Client {
 TEST_CASE(
     "Client::netx_setnonblocking() deals with Client::ioctlsocket() failure") {
   FailIoctlsocket client;
-  REQUIRE(client.netx_setnonblocking(17) == libndt::Err::invalid_argument);
+  REQUIRE(client.netx_setnonblocking(17, true) ==
+          libndt::Err::invalid_argument);
 }
 
 #else
@@ -2488,10 +2489,10 @@ class FailFcntl2 : public libndt::Client {
   }
 };
 
-TEST_CASE(
-    "Client::netx_setnonblocking() deals with Client::fcntl2() failure") {
+TEST_CASE("Client::netx_setnonblocking() deals with Client::fcntl2() failure") {
   FailFcntl2 client;
-  REQUIRE(client.netx_setnonblocking(17) == libndt::Err::invalid_argument);
+  REQUIRE(client.netx_setnonblocking(17, true) ==
+          libndt::Err::invalid_argument);
 }
 
 class FailFcntl3i : public libndt::Client {
@@ -2512,7 +2513,8 @@ class FailFcntl3i : public libndt::Client {
 TEST_CASE(
     "Client::netx_setnonblocking() deals with Client::fcntl3i() failure") {
   FailFcntl3i client;
-  REQUIRE(client.netx_setnonblocking(17) == libndt::Err::invalid_argument);
+  REQUIRE(client.netx_setnonblocking(17, true) ==
+          libndt::Err::invalid_argument);
 }
 
 #endif // _WIN32

--- a/libndt_test.cpp
+++ b/libndt_test.cpp
@@ -659,8 +659,8 @@ class FailRecvDuringDownload : public libndt::Client {
                           timeval *) noexcept override {
     return libndt::Err::none;
   }
-  libndt::Err netx_recv(libndt::Socket, void *, libndt::Size,
-                        libndt::Size *) noexcept override {
+  libndt::Err netx_recv_nonblocking(libndt::Socket, void *, libndt::Size,
+                                    libndt::Size *) noexcept override {
     return libndt::Err::invalid_argument;
   }
 };
@@ -686,8 +686,8 @@ class RecvEofDuringDownload : public libndt::Client {
                           timeval *) noexcept override {
     return libndt::Err::none;
   }
-  libndt::Err netx_recv(libndt::Socket, void *, libndt::Size,
-                        libndt::Size *) noexcept override {
+  libndt::Err netx_recv_nonblocking(libndt::Socket, void *, libndt::Size,
+                                    libndt::Size *) noexcept override {
     return libndt::Err::eof;
   }
 };
@@ -715,8 +715,8 @@ class FailMsgReadLegacyDuringDownload : public libndt::Client {
                           timeval *) noexcept override {
     return libndt::Err::none;
   }
-  libndt::Err netx_recv(libndt::Socket, void *, libndt::Size,
-                        libndt::Size *) noexcept override {
+  libndt::Err netx_recv_nonblocking(libndt::Socket, void *, libndt::Size,
+                                    libndt::Size *) noexcept override {
     return libndt::Err::eof;
   }
   bool msg_read_legacy(uint8_t *, std::string *) noexcept override {
@@ -746,8 +746,8 @@ class RecvNonTestMsgDuringDownload : public libndt::Client {
                           timeval *) noexcept override {
     return libndt::Err::none;
   }
-  libndt::Err netx_recv(libndt::Socket, void *, libndt::Size,
-                        libndt::Size *) noexcept override {
+  libndt::Err netx_recv_nonblocking(libndt::Socket, void *, libndt::Size,
+                                    libndt::Size *) noexcept override {
     return libndt::Err::eof;
   }
   bool msg_read_legacy(uint8_t *code, std::string *) noexcept override {
@@ -777,8 +777,8 @@ class FailMsgWriteDuringDownload : public libndt::Client {
                           timeval *) noexcept override {
     return libndt::Err::none;
   }
-  libndt::Err netx_recv(libndt::Socket, void *, libndt::Size,
-                        libndt::Size *) noexcept override {
+  libndt::Err netx_recv_nonblocking(libndt::Socket, void *, libndt::Size,
+                                    libndt::Size *) noexcept override {
     return libndt::Err::eof;
   }
   bool msg_read_legacy(uint8_t *code, std::string *) noexcept override {
@@ -809,8 +809,8 @@ class FailMsgReadDuringDownload : public libndt::Client {
                           timeval *) noexcept override {
     return libndt::Err::none;
   }
-  libndt::Err netx_recv(libndt::Socket, void *, libndt::Size,
-                        libndt::Size *) noexcept override {
+  libndt::Err netx_recv_nonblocking(libndt::Socket, void *, libndt::Size,
+                                    libndt::Size *) noexcept override {
     return libndt::Err::eof;
   }
   bool msg_read_legacy(uint8_t *code, std::string *) noexcept override {
@@ -842,8 +842,8 @@ class RecvNonTestOrLogoutMsgDuringDownload : public libndt::Client {
                           timeval *) noexcept override {
     return libndt::Err::none;
   }
-  libndt::Err netx_recv(libndt::Socket, void *, libndt::Size,
-                        libndt::Size *) noexcept override {
+  libndt::Err netx_recv_nonblocking(libndt::Socket, void *, libndt::Size,
+                                    libndt::Size *) noexcept override {
     return libndt::Err::eof;
   }
   bool msg_read_legacy(uint8_t *code, std::string *) noexcept override {
@@ -878,8 +878,8 @@ class FailEmitResultDuringDownload : public libndt::Client {
                           timeval *) noexcept override {
     return libndt::Err::none;
   }
-  libndt::Err netx_recv(libndt::Socket, void *, libndt::Size,
-                        libndt::Size *) noexcept override {
+  libndt::Err netx_recv_nonblocking(libndt::Socket, void *, libndt::Size,
+                                    libndt::Size *) noexcept override {
     return libndt::Err::eof;
   }
   bool msg_read_legacy(uint8_t *code, std::string *) noexcept override {
@@ -915,8 +915,8 @@ class TooManyTestMsgsDuringDownload : public libndt::Client {
                           timeval *) noexcept override {
     return libndt::Err::none;
   }
-  libndt::Err netx_recv(libndt::Socket, void *, libndt::Size,
-                        libndt::Size *) noexcept override {
+  libndt::Err netx_recv_nonblocking(libndt::Socket, void *, libndt::Size,
+                                    libndt::Size *) noexcept override {
     return libndt::Err::eof;
   }
   bool msg_read_legacy(uint8_t *code, std::string *) noexcept override {
@@ -1063,8 +1063,8 @@ class FailSendDuringUpload : public libndt::Client {
                           timeval *) noexcept override {
     return libndt::Err::none;
   }
-  libndt::Err netx_send(libndt::Socket, const void *, libndt::Size,
-                        libndt::Size *) noexcept override {
+  libndt::Err netx_send_nonblocking(libndt::Socket, const void *, libndt::Size,
+                                    libndt::Size *) noexcept override {
     return libndt::Err::io_error;
   }
 };
@@ -1097,8 +1097,8 @@ class FailMsgExpectDuringUpload : public libndt::Client {
                           timeval *) noexcept override {
     return libndt::Err::none;
   }
-  libndt::Err netx_send(libndt::Socket, const void *, libndt::Size,
-                        libndt::Size *) noexcept override {
+  libndt::Err netx_send_nonblocking(libndt::Socket, const void *, libndt::Size,
+                                    libndt::Size *) noexcept override {
     return libndt::Err::io_error;
   }
   bool msg_expect(uint8_t, std::string *) noexcept override { return false; }
@@ -1127,8 +1127,8 @@ class FailFinalMsgExpectEmptyDuringUpload : public libndt::Client {
                           timeval *) noexcept override {
     return libndt::Err::none;
   }
-  libndt::Err netx_send(libndt::Socket, const void *, libndt::Size,
-                        libndt::Size *) noexcept override {
+  libndt::Err netx_send_nonblocking(libndt::Socket, const void *, libndt::Size,
+                                    libndt::Size *) noexcept override {
     return libndt::Err::io_error;
   }
   bool msg_expect(uint8_t, std::string *) noexcept override { return true; }


### PR DESCRIPTION
Required to introduce SSL, where, if we don't set nonblocking, we risk blocking indefinitely. In fact, a `SSL_read` can call both `recv()` and `send()`. If we have nonblocking code, instead, we will get specific errors when SSL wants to read and to write, thus we can use select() properly.