### PR TITLE
libndt: increase type sanity

### DIFF
--- a/libndt-client.cpp
+++ b/libndt-client.cpp
@@ -32,7 +32,7 @@ static void usage() {
 int main(int, char **argv) {
   libndt::Settings settings;
   settings.verbosity = libndt::verbosity_quiet;
-  settings.nettest_flags = 0;  // you need to enable tests explicitly
+  settings.nettest_flags = libndt::NettestFlags{0};  // you need to enable tests explicitly
 
   {
     argh::parser cmdline;

--- a/libndt.cpp
+++ b/libndt.cpp
@@ -1515,7 +1515,7 @@ again:
 
 // Dependencies (curl)
 
-uint32_t Client::get_verbosity() const noexcept {
+Verbosity Client::get_verbosity() const noexcept {
   return impl->settings.verbosity;
 }
 

--- a/libndt.hpp
+++ b/libndt.hpp
@@ -97,17 +97,44 @@ using Socket = int64_t;
 
 using SockLen = int;
 
+#if 0
+class ProtocolFlags {
+ public:
+  explicit ProtocolFlags(unsigned int v) noexcept : value_{v} {}
+  bool operator==(const ProtocolFlags &other) const noexcept {
+    return value_ == other.value_;
+  }
+  bool operator!=(const ProtocolFlags &other) const noexcept {
+    return value_ != other.value_;
+  }
+  bool operator<(const ProtocolFlags &other) const noexcept {
+    return value_ < other.value_;
+  }
+  bool operator&(const ProtocolFlags &other) const noexcept {
+    return value_ & other.value_;
+  }
+  unsigned int as_value() const noexcept { return value_; }
+ private:
+  unsigned int value_;
+};
+#define constexpr const
+#undef constexpr
+#endif
+
+/// Flags to select what protocol should be used.
+using ProtocolFlags = unsigned int;
+
 /// When this flag is set we use JSON messages. This specifically means that
 /// we send and receive JSON messages (as opposed to raw strings).
-constexpr uint32_t protocol_flag_json = (1 << 0);
+constexpr ProtocolFlags protocol_flag_json = ProtocolFlags{1 << 0};
 
 /// When this flag is set we use TLS. This specifically means that we will
 /// use TLS channels for the control and the measurement connections.
-constexpr uint32_t protocol_flag_tls = (1 << 1);
+constexpr ProtocolFlags protocol_flag_tls = ProtocolFlags{1 << 1};
 
 /// When this flag is set we use WebSockets. This specifically means that
 /// we use the WebSockets framing (as opposed to the original binary framing).
-constexpr uint32_t protocol_flag_websockets = (1 << 2);
+constexpr ProtocolFlags protocol_flag_websockets = ProtocolFlags{1 << 2};
 
 enum class Err;  // Forward declaration (see bottom of this file)
 
@@ -147,7 +174,7 @@ class Settings {
   /// Type of NDT protocol that you want to use. Depending on the requested
   /// protocol, you may need to change also the port. By default, NDT listens
   /// on port 3001 for in-clear communications and port 3010 for TLS ones.
-  uint32_t protocol_flags = 0;
+  ProtocolFlags protocol_flags = ProtocolFlags{0};
 
   /// Maximum time for which a nettest (i.e. download) is allowed to run. After
   /// this time has elapsed, the code will stop downloading (or uploading). It

--- a/libndt.hpp
+++ b/libndt.hpp
@@ -59,24 +59,72 @@ constexpr Version version_minor = Version{24};
 /// Patch API version number of measurement-kit/libndt.
 constexpr Version version_patch = Version{0};
 
-constexpr uint8_t nettest_flag_middlebox = 1U << 0;
+#if 0
+class NettestFlags {
+ public:
+  //explicit NettestFlags(char v) noexcept : value_{(unsigned char)v} {}
+  explicit NettestFlags(unsigned char v) noexcept : value_{v} {}
+  bool operator==(const NettestFlags &other) const noexcept {
+    return value_ == other.value_;
+  }
+  bool operator!=(const NettestFlags &other) const noexcept {
+    return value_ != other.value_;
+  }
+  bool operator<(const NettestFlags &other) const noexcept {
+    return value_ < other.value_;
+  }
+  bool operator>=(const NettestFlags &other) const noexcept {
+    return value_ >= other.value_;
+  }
+  NettestFlags operator&(const NettestFlags &other) const noexcept {
+    unsigned char v = value_ & other.value_;
+    return NettestFlags{v};
+  }
+  NettestFlags operator|(const NettestFlags &other) const noexcept {
+    unsigned char v = value_ | other.value_;
+    return NettestFlags{v};
+  }
+  NettestFlags operator~() const noexcept {
+    unsigned char v = ~value_;
+    return NettestFlags{v};
+  }
+  NettestFlags &operator|=(const NettestFlags &other)  noexcept {
+    value_ |= other.value_;
+    return *this;
+  }
+  NettestFlags &operator&=(const NettestFlags &other)  noexcept {
+    value_ &= other.value_;
+    return *this;
+  }
+  unsigned char as_value() const noexcept { return value_; }
+ private:
+  unsigned char value_;
+};
+#define constexpr const
+#undef constexpr
+#endif
 
-/// The upload net test.
-constexpr uint8_t nettest_flag_upload = 1U << 1;
+/// Flags that indicate what subtests to run.
+using NettestFlags = unsigned char;
 
-/// The download net test.
-constexpr uint8_t nettest_flag_download = 1U << 2;
+constexpr NettestFlags nettest_flag_middlebox = NettestFlags{1U << 0};
 
-constexpr uint8_t nettest_flag_simple_firewall = 1U << 3;
+/// Run the upload subtest.
+constexpr NettestFlags nettest_flag_upload = NettestFlags{1U << 1};
 
-constexpr uint8_t nettest_flag_status = 1U << 4;
+/// Run the download subtest.
+constexpr NettestFlags nettest_flag_download = NettestFlags{1U << 2};
 
-constexpr uint8_t nettest_flag_meta = 1U << 5;
+constexpr NettestFlags nettest_flag_simple_firewall = NettestFlags{1U << 3};
 
-constexpr uint8_t nettest_flag_upload_ext = 1U << 6;
+constexpr NettestFlags nettest_flag_status = NettestFlags{1U << 4};
 
-/// The multi-stream download net test.
-constexpr uint8_t nettest_flag_download_ext = 1U << 7;
+constexpr NettestFlags nettest_flag_meta = NettestFlags{1U << 5};
+
+constexpr NettestFlags nettest_flag_upload_ext = NettestFlags{1U << 6};
+
+/// Run the multi-stream download subtest.
+constexpr NettestFlags nettest_flag_download_ext = NettestFlags{1U << 7};
 
 /// Library's logging verbosity.
 using Verbosity = unsigned int;
@@ -140,7 +188,7 @@ class Settings {
   std::string port = "3001";
 
   /// The tests you want to run with the NDT server.
-  uint8_t nettest_flags = nettest_flag_download;
+  NettestFlags nettest_flags = nettest_flag_download;
 
   /// Verbosity of the client. By default no message is emitted. Set to other
   /// values to get more messages (useful when debugging).
@@ -168,34 +216,6 @@ class Settings {
   /// empty, all DNS and TCP traffic should be tunnelled over such port.
   std::string socks5h_port;
 };
-
-#if 0
-class MsgType {
- public:
-  //explicit MsgType(char v) noexcept : value_{(unsigned char)v} {}
-  explicit MsgType(unsigned char v) noexcept : value_{v} {}
-  bool operator==(const MsgType &other) const noexcept {
-    return value_ == other.value_;
-  }
-  bool operator!=(const MsgType &other) const noexcept {
-    return value_ != other.value_;
-  }
-  bool operator<(const MsgType &other) const noexcept {
-    return value_ < other.value_;
-  }
-  bool operator>=(const MsgType &other) const noexcept {
-    return value_ >= other.value_;
-  }
-  bool operator&(const MsgType &other) const noexcept {
-    return value_ & other.value_;
-  }
-  unsigned char as_value() const noexcept { return value_; }
- private:
-  unsigned char value_;
-};
-#define constexpr const
-#undef constexpr
-#endif
 
 using MsgType = unsigned char;
 
@@ -255,7 +275,7 @@ class Client {
   /// get the percentage of completion of the current nettest. @remark We
   /// provide you with @p tid, so you know whether the nettest is downloading
   /// bytes from the server or uploading bytes to the server.
-  virtual void on_performance(uint8_t tid, uint8_t nflows,
+  virtual void on_performance(NettestFlags tid, uint8_t nflows,
                               double measured_bytes,
                               double measurement_interval, double elapsed,
                               double max_runtime);

--- a/libndt.hpp
+++ b/libndt.hpp
@@ -47,33 +47,6 @@
 /// Contains measurement-kit/libndt code.
 namespace libndt {
 
-#if 0
-class Version {
- public:
-  explicit Version(unsigned int v) noexcept : value_{v} {}
-  bool operator==(const Version &other) const noexcept {
-    return value_ == other.value_;
-  }
-  bool operator!=(const Version &other) const noexcept {
-    return value_ != other.value_;
-  }
-  bool operator<(const Version &other) const noexcept {
-    return value_ < other.value_;
-  }
-  bool operator>=(const Version &other) const noexcept {
-    return value_ >= other.value_;
-  }
-  bool operator&(const Version &other) const noexcept {
-    return value_ & other.value_;
-  }
-  unsigned int as_value() const noexcept { return value_; }
- private:
-  unsigned int value_;
-};
-#define constexpr const
-#undef constexpr
-#endif
-
 /// Type containing a version number.
 using Version = unsigned int;
 
@@ -196,6 +169,36 @@ class Settings {
   std::string socks5h_port;
 };
 
+#if 0
+class MsgType {
+ public:
+  //explicit MsgType(char v) noexcept : value_{(unsigned char)v} {}
+  explicit MsgType(unsigned char v) noexcept : value_{v} {}
+  bool operator==(const MsgType &other) const noexcept {
+    return value_ == other.value_;
+  }
+  bool operator!=(const MsgType &other) const noexcept {
+    return value_ != other.value_;
+  }
+  bool operator<(const MsgType &other) const noexcept {
+    return value_ < other.value_;
+  }
+  bool operator>=(const MsgType &other) const noexcept {
+    return value_ >= other.value_;
+  }
+  bool operator&(const MsgType &other) const noexcept {
+    return value_ & other.value_;
+  }
+  unsigned char as_value() const noexcept { return value_; }
+ private:
+  unsigned char value_;
+};
+#define constexpr const
+#undef constexpr
+#endif
+
+using MsgType = unsigned char;
+
 /// NDT client. In the typical usage, you just need to construct a Client,
 /// optionally providing settings, and to call the run() method. More advanced
 /// usage may require you to override methods in a subclass to customize the
@@ -309,20 +312,20 @@ class Client {
 
   bool msg_write_login(const std::string &version) noexcept;
 
-  virtual bool msg_write(uint8_t code, std::string &&msg) noexcept;
+  virtual bool msg_write(MsgType code, std::string &&msg) noexcept;
 
-  virtual bool msg_write_legacy(uint8_t code, std::string &&msg) noexcept;
+  virtual bool msg_write_legacy(MsgType code, std::string &&msg) noexcept;
 
   virtual bool msg_expect_test_prepare(  //
       std::string *pport, uint8_t *pnflows) noexcept;
 
-  virtual bool msg_expect_empty(uint8_t code) noexcept;
+  virtual bool msg_expect_empty(MsgType code) noexcept;
 
-  virtual bool msg_expect(uint8_t code, std::string *msg) noexcept;
+  virtual bool msg_expect(MsgType code, std::string *msg) noexcept;
 
-  virtual bool msg_read(uint8_t *code, std::string *msg) noexcept;
+  virtual bool msg_read(MsgType *code, std::string *msg) noexcept;
 
-  virtual bool msg_read_legacy(uint8_t *code, std::string *msg) noexcept;
+  virtual bool msg_read_legacy(MsgType *code, std::string *msg) noexcept;
 
   // Networking layer
 
@@ -402,19 +405,6 @@ class Client {
   std::unique_ptr<Impl> impl;
 };
 
-constexpr uint8_t msg_comm_failure = 0;
-constexpr uint8_t msg_srv_queue = 1;
-constexpr uint8_t msg_login = 2;
-constexpr uint8_t msg_test_prepare = 3;
-constexpr uint8_t msg_test_start = 4;
-constexpr uint8_t msg_test_msg = 5;
-constexpr uint8_t msg_test_finalize = 6;
-constexpr uint8_t msg_error = 7;
-constexpr uint8_t msg_results = 8;
-constexpr uint8_t msg_logout = 9;
-constexpr uint8_t msg_waiting = 10;
-constexpr uint8_t msg_extended_login = 11;
-
 enum class Err {
   none,
   broken_pipe,
@@ -438,6 +428,19 @@ enum class Err {
   ai_noname,
   socks5h,
 };
+
+constexpr MsgType msg_comm_failure = MsgType{0};
+constexpr MsgType msg_srv_queue = MsgType{1};
+constexpr MsgType msg_login = MsgType{2};
+constexpr MsgType msg_test_prepare = MsgType{3};
+constexpr MsgType msg_test_start = MsgType{4};
+constexpr MsgType msg_test_msg = MsgType{5};
+constexpr MsgType msg_test_finalize = MsgType{6};
+constexpr MsgType msg_error = MsgType{7};
+constexpr MsgType msg_results = MsgType{8};
+constexpr MsgType msg_logout = MsgType{9};
+constexpr MsgType msg_waiting = MsgType{10};
+constexpr MsgType msg_extended_login = MsgType{11};
 
 }  // namespace libndt
 #endif

--- a/libndt.hpp
+++ b/libndt.hpp
@@ -124,7 +124,7 @@ constexpr ProtocolFlags protocol_flag_websockets = ProtocolFlags{1 << 2};
 enum class Err;  // Forward declaration (see bottom of this file)
 
 /// Timeout expressed in seconds.
-using Timeout = unsigned short;
+using Timeout = unsigned int;
 
 /// NDT client settings. If you do not customize the settings when creating
 /// a Client, the defaults listed below will be used instead.

--- a/libndt.hpp
+++ b/libndt.hpp
@@ -75,17 +75,47 @@ constexpr uint8_t nettest_flag_upload_ext = 1U << 6;
 /// The multi-stream download net test.
 constexpr uint8_t nettest_flag_download_ext = 1U << 7;
 
+#if 0
+class Verbosity {
+ public:
+  explicit Verbosity(unsigned int v) noexcept : value_{v} {}
+  bool operator==(const Verbosity &other) const noexcept {
+    return value_ == other.value_;
+  }
+  bool operator!=(const Verbosity &other) const noexcept {
+    return value_ != other.value_;
+  }
+  bool operator<(const Verbosity &other) const noexcept {
+    return value_ < other.value_;
+  }
+  bool operator>=(const Verbosity &other) const noexcept {
+    return value_ >= other.value_;
+  }
+  bool operator&(const Verbosity &other) const noexcept {
+    return value_ & other.value_;
+  }
+  unsigned int as_value() const noexcept { return value_; }
+ private:
+  unsigned int value_;
+};
+#define constexpr const
+#undef constexpr
+#endif
+
+/// Library's logging verbosity.
+using Verbosity = unsigned int;
+
 /// Do not emit any log message.
-constexpr uint32_t verbosity_quiet = 0;
+constexpr Verbosity verbosity_quiet = Verbosity{0};
 
 /// Emit only warning messages.
-constexpr uint32_t verbosity_warning = 1;
+constexpr Verbosity verbosity_warning = Verbosity{1};
 
 /// Emit warning and informational messages.
-constexpr uint32_t verbosity_info = 2;
+constexpr Verbosity verbosity_info = Verbosity{2};
 
 /// Emit all log messages.
-constexpr uint32_t verbosity_debug = 3;
+constexpr Verbosity verbosity_debug = Verbosity{3};
 
 constexpr const char *ndt_version_compat = "v3.7.0";
 
@@ -96,30 +126,6 @@ using Ssize = int64_t;
 using Socket = int64_t;
 
 using SockLen = int;
-
-#if 0
-class ProtocolFlags {
- public:
-  explicit ProtocolFlags(unsigned int v) noexcept : value_{v} {}
-  bool operator==(const ProtocolFlags &other) const noexcept {
-    return value_ == other.value_;
-  }
-  bool operator!=(const ProtocolFlags &other) const noexcept {
-    return value_ != other.value_;
-  }
-  bool operator<(const ProtocolFlags &other) const noexcept {
-    return value_ < other.value_;
-  }
-  bool operator&(const ProtocolFlags &other) const noexcept {
-    return value_ & other.value_;
-  }
-  unsigned int as_value() const noexcept { return value_; }
- private:
-  unsigned int value_;
-};
-#define constexpr const
-#undef constexpr
-#endif
 
 /// Flags to select what protocol should be used.
 using ProtocolFlags = unsigned int;
@@ -162,7 +168,7 @@ class Settings {
 
   /// Verbosity of the client. By default no message is emitted. Set to other
   /// values to get more messages (useful when debugging).
-  uint32_t verbosity = verbosity_quiet;
+  Verbosity verbosity = verbosity_quiet;
 
   /// Metadata to include in the server side logs. By default we just identify
   /// the NDT version and the application.
@@ -348,7 +354,7 @@ class Client {
 
   // Dependencies (cURL)
 
-  uint32_t get_verbosity() const noexcept;
+  Verbosity get_verbosity() const noexcept;
 
   virtual bool query_mlabns_curl(const std::string &url, long timeout,
                                  std::string *body) noexcept;

--- a/libndt.hpp
+++ b/libndt.hpp
@@ -47,14 +47,44 @@
 /// Contains measurement-kit/libndt code.
 namespace libndt {
 
+#if 0
+class Version {
+ public:
+  explicit Version(unsigned int v) noexcept : value_{v} {}
+  bool operator==(const Version &other) const noexcept {
+    return value_ == other.value_;
+  }
+  bool operator!=(const Version &other) const noexcept {
+    return value_ != other.value_;
+  }
+  bool operator<(const Version &other) const noexcept {
+    return value_ < other.value_;
+  }
+  bool operator>=(const Version &other) const noexcept {
+    return value_ >= other.value_;
+  }
+  bool operator&(const Version &other) const noexcept {
+    return value_ & other.value_;
+  }
+  unsigned int as_value() const noexcept { return value_; }
+ private:
+  unsigned int value_;
+};
+#define constexpr const
+#undef constexpr
+#endif
+
+/// Type containing a version number.
+using Version = unsigned int;
+
 /// Major API version number of measurement-kit/libndt.
-constexpr uint32_t version_major = 0;
+constexpr Version version_major = Version{0};
 
 /// Minor API version number of measurement-kit/libndt.
-constexpr uint32_t version_minor = 24;
+constexpr Version version_minor = Version{24};
 
 /// Patch API version number of measurement-kit/libndt.
-constexpr uint32_t version_patch = 0;
+constexpr Version version_patch = Version{0};
 
 constexpr uint8_t nettest_flag_middlebox = 1U << 0;
 
@@ -74,33 +104,6 @@ constexpr uint8_t nettest_flag_upload_ext = 1U << 6;
 
 /// The multi-stream download net test.
 constexpr uint8_t nettest_flag_download_ext = 1U << 7;
-
-#if 0
-class Verbosity {
- public:
-  explicit Verbosity(unsigned int v) noexcept : value_{v} {}
-  bool operator==(const Verbosity &other) const noexcept {
-    return value_ == other.value_;
-  }
-  bool operator!=(const Verbosity &other) const noexcept {
-    return value_ != other.value_;
-  }
-  bool operator<(const Verbosity &other) const noexcept {
-    return value_ < other.value_;
-  }
-  bool operator>=(const Verbosity &other) const noexcept {
-    return value_ >= other.value_;
-  }
-  bool operator&(const Verbosity &other) const noexcept {
-    return value_ & other.value_;
-  }
-  unsigned int as_value() const noexcept { return value_; }
- private:
-  unsigned int value_;
-};
-#define constexpr const
-#undef constexpr
-#endif
 
 /// Library's logging verbosity.
 using Verbosity = unsigned int;

--- a/libndt.hpp
+++ b/libndt.hpp
@@ -59,51 +59,6 @@ constexpr Version version_minor = Version{24};
 /// Patch API version number of measurement-kit/libndt.
 constexpr Version version_patch = Version{0};
 
-#if 0
-class NettestFlags {
- public:
-  //explicit NettestFlags(char v) noexcept : value_{(unsigned char)v} {}
-  explicit NettestFlags(unsigned char v) noexcept : value_{v} {}
-  bool operator==(const NettestFlags &other) const noexcept {
-    return value_ == other.value_;
-  }
-  bool operator!=(const NettestFlags &other) const noexcept {
-    return value_ != other.value_;
-  }
-  bool operator<(const NettestFlags &other) const noexcept {
-    return value_ < other.value_;
-  }
-  bool operator>=(const NettestFlags &other) const noexcept {
-    return value_ >= other.value_;
-  }
-  NettestFlags operator&(const NettestFlags &other) const noexcept {
-    unsigned char v = value_ & other.value_;
-    return NettestFlags{v};
-  }
-  NettestFlags operator|(const NettestFlags &other) const noexcept {
-    unsigned char v = value_ | other.value_;
-    return NettestFlags{v};
-  }
-  NettestFlags operator~() const noexcept {
-    unsigned char v = ~value_;
-    return NettestFlags{v};
-  }
-  NettestFlags &operator|=(const NettestFlags &other)  noexcept {
-    value_ |= other.value_;
-    return *this;
-  }
-  NettestFlags &operator&=(const NettestFlags &other)  noexcept {
-    value_ &= other.value_;
-    return *this;
-  }
-  unsigned char as_value() const noexcept { return value_; }
- private:
-  unsigned char value_;
-};
-#define constexpr const
-#undef constexpr
-#endif
-
 /// Flags that indicate what subtests to run.
 using NettestFlags = unsigned char;
 
@@ -168,6 +123,9 @@ constexpr ProtocolFlags protocol_flag_websockets = ProtocolFlags{1 << 2};
 
 enum class Err;  // Forward declaration (see bottom of this file)
 
+/// Timeout expressed in seconds.
+using Timeout = unsigned short;
+
 /// NDT client settings. If you do not customize the settings when creating
 /// a Client, the defaults listed below will be used instead.
 class Settings {
@@ -178,7 +136,7 @@ class Settings {
 
   /// Timeout used for I/O operations. \bug in v0.23.0 this timeout is only
   /// used for cURL operations, but this will be fixed in v0.24.0.
-  uint16_t timeout = 3 /* seconds */;
+  Timeout timeout = Timeout{3} /* seconds */;
 
   /// Host name of the NDT server to use. If this is left blank (the default),
   /// we will use mlab-ns to discover a nearby server.
@@ -210,7 +168,7 @@ class Settings {
   /// this time has elapsed, the code will stop downloading (or uploading). It
   /// is meant as a safeguard to prevent the test for running for much more time
   /// than anticipated, due to buffering and/or changing network conditions.
-  uint16_t max_runtime = 14 /* seconds */;
+  Timeout max_runtime = Timeout{14} /* seconds */;
 
   /// SOCKSv5h port to use for tunnelling traffic using, e.g., Tor. If non
   /// empty, all DNS and TCP traffic should be tunnelled over such port.

--- a/libndt_test.cpp
+++ b/libndt_test.cpp
@@ -331,7 +331,7 @@ TEST_CASE("Client::recv_kickoff() deals with invalid kickoff") {
 class FailMsgExpect : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_expect(uint8_t, std::string *) noexcept override { return false; }
+  bool msg_expect(libndt::MsgType, std::string *) noexcept override { return false; }
 };
 
 TEST_CASE("Client::wait_in_queue() deals with Client::msg_expect() failure") {
@@ -342,7 +342,7 @@ TEST_CASE("Client::wait_in_queue() deals with Client::msg_expect() failure") {
 class ServerBusy : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_expect(uint8_t, std::string *val) noexcept override {
+  bool msg_expect(libndt::MsgType, std::string *val) noexcept override {
     *val = "9999";
     return true;
   }
@@ -372,7 +372,7 @@ TEST_CASE("Client::recv_tests_ids() deals with Client::msg_expect() failure") {
 class InvalidTestsIds : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_expect(uint8_t, std::string *val) noexcept override {
+  bool msg_expect(libndt::MsgType, std::string *val) noexcept override {
     *val = "777 888 999";
     return true;
   }
@@ -389,7 +389,7 @@ TEST_CASE("Client::recv_tests_ids() fails with invalid tests ids") {
 class RunTestsMock : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_expect(uint8_t, std::string *val) noexcept override {
+  bool msg_expect(libndt::MsgType, std::string *val) noexcept override {
     *val = tests_ids;
     return true;
   }
@@ -435,7 +435,7 @@ TEST_CASE("Client::run_tests() deals with unexpected test-id") {
 class FailMsgRead : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_read(uint8_t *, std::string *) noexcept override { return false; }
+  bool msg_read(libndt::MsgType *, std::string *) noexcept override { return false; }
 };
 
 TEST_CASE(
@@ -447,7 +447,7 @@ TEST_CASE(
 class NeitherResultsNorLogout : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_read(uint8_t *code, std::string *msg) noexcept override {
+  bool msg_read(libndt::MsgType *code, std::string *msg) noexcept override {
     *code = libndt::msg_comm_failure;
     *msg = "";
     return true;
@@ -462,7 +462,7 @@ TEST_CASE("Client::recv_results_and_logout() deals with unexpected message") {
 class InvalidResults : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_read(uint8_t *code, std::string *msg) noexcept override {
+  bool msg_read(libndt::MsgType *code, std::string *msg) noexcept override {
     *code = libndt::msg_results;
     *msg = "antani-antani";
     return true;
@@ -477,7 +477,7 @@ TEST_CASE("Client::recv_results_and_logout() deals with invalid results") {
 class TooManyResults : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_read(uint8_t *code, std::string *msg) noexcept override {
+  bool msg_read(libndt::MsgType *code, std::string *msg) noexcept override {
     *code = libndt::msg_results;
     *msg = "antani:antani";
     return true;
@@ -609,7 +609,7 @@ class FailMsgExpectEmpty : public libndt::Client {
     *sock = 17 /* Something "valid" */;
     return libndt::Err::none;
   }
-  bool msg_expect_empty(uint8_t) noexcept override { return false; }
+  bool msg_expect_empty(libndt::MsgType) noexcept override { return false; }
 };
 
 TEST_CASE(
@@ -629,7 +629,7 @@ class FailNetxSelectDuringDownload : public libndt::Client {
     *sock = 17 /* Something "valid" */;
     return libndt::Err::none;
   }
-  bool msg_expect_empty(uint8_t) noexcept override { return true; }
+  bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
   libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
                           timeval *) noexcept override {
     return libndt::Err::io_error;
@@ -652,7 +652,7 @@ class FailRecvDuringDownload : public libndt::Client {
     *sock = 17 /* Something "valid" */;
     return libndt::Err::none;
   }
-  bool msg_expect_empty(uint8_t) noexcept override { return true; }
+  bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
   libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
                           timeval *) noexcept override {
     return libndt::Err::none;
@@ -679,7 +679,7 @@ class RecvEofDuringDownload : public libndt::Client {
     *sock = 17 /* Something "valid" */;
     return libndt::Err::none;
   }
-  bool msg_expect_empty(uint8_t) noexcept override { return true; }
+  bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
   libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
                           timeval *) noexcept override {
     return libndt::Err::none;
@@ -708,7 +708,7 @@ class FailMsgReadLegacyDuringDownload : public libndt::Client {
     *sock = 17 /* Something "valid" */;
     return libndt::Err::none;
   }
-  bool msg_expect_empty(uint8_t) noexcept override { return true; }
+  bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
   libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
                           timeval *) noexcept override {
     return libndt::Err::none;
@@ -717,7 +717,7 @@ class FailMsgReadLegacyDuringDownload : public libndt::Client {
                         libndt::Size *) noexcept override {
     return libndt::Err::eof;
   }
-  bool msg_read_legacy(uint8_t *, std::string *) noexcept override {
+  bool msg_read_legacy(libndt::MsgType *, std::string *) noexcept override {
     return false;
   }
 };
@@ -739,7 +739,7 @@ class RecvNonTestMsgDuringDownload : public libndt::Client {
     *sock = 17 /* Something "valid" */;
     return libndt::Err::none;
   }
-  bool msg_expect_empty(uint8_t) noexcept override { return true; }
+  bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
   libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
                           timeval *) noexcept override {
     return libndt::Err::none;
@@ -748,7 +748,7 @@ class RecvNonTestMsgDuringDownload : public libndt::Client {
                         libndt::Size *) noexcept override {
     return libndt::Err::eof;
   }
-  bool msg_read_legacy(uint8_t *code, std::string *) noexcept override {
+  bool msg_read_legacy(libndt::MsgType *code, std::string *) noexcept override {
     *code = libndt::msg_logout;
     return true;
   }
@@ -770,7 +770,7 @@ class FailMsgWriteDuringDownload : public libndt::Client {
     *sock = 17 /* Something "valid" */;
     return libndt::Err::none;
   }
-  bool msg_expect_empty(uint8_t) noexcept override { return true; }
+  bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
   libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
                           timeval *) noexcept override {
     return libndt::Err::none;
@@ -779,11 +779,11 @@ class FailMsgWriteDuringDownload : public libndt::Client {
                         libndt::Size *) noexcept override {
     return libndt::Err::eof;
   }
-  bool msg_read_legacy(uint8_t *code, std::string *) noexcept override {
+  bool msg_read_legacy(libndt::MsgType *code, std::string *) noexcept override {
     *code = libndt::msg_test_msg;
     return true;
   }
-  bool msg_write(uint8_t, std::string &&) noexcept override { return false; }
+  bool msg_write(libndt::MsgType, std::string &&) noexcept override { return false; }
 };
 
 TEST_CASE("Client::run_download() deals with Client::msg_write() failure") {
@@ -802,7 +802,7 @@ class FailMsgReadDuringDownload : public libndt::Client {
     *sock = 17 /* Something "valid" */;
     return libndt::Err::none;
   }
-  bool msg_expect_empty(uint8_t) noexcept override { return true; }
+  bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
   libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
                           timeval *) noexcept override {
     return libndt::Err::none;
@@ -811,12 +811,12 @@ class FailMsgReadDuringDownload : public libndt::Client {
                         libndt::Size *) noexcept override {
     return libndt::Err::eof;
   }
-  bool msg_read_legacy(uint8_t *code, std::string *) noexcept override {
+  bool msg_read_legacy(libndt::MsgType *code, std::string *) noexcept override {
     *code = libndt::msg_test_msg;
     return true;
   }
-  bool msg_write(uint8_t, std::string &&) noexcept override { return true; }
-  bool msg_read(uint8_t *, std::string *) noexcept override { return false; }
+  bool msg_write(libndt::MsgType, std::string &&) noexcept override { return true; }
+  bool msg_read(libndt::MsgType *, std::string *) noexcept override { return false; }
 };
 
 TEST_CASE("Client::run_download() deals with Client::msg_read() failure") {
@@ -835,7 +835,7 @@ class RecvNonTestOrLogoutMsgDuringDownload : public libndt::Client {
     *sock = 17 /* Something "valid" */;
     return libndt::Err::none;
   }
-  bool msg_expect_empty(uint8_t) noexcept override { return true; }
+  bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
   libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
                           timeval *) noexcept override {
     return libndt::Err::none;
@@ -844,12 +844,12 @@ class RecvNonTestOrLogoutMsgDuringDownload : public libndt::Client {
                         libndt::Size *) noexcept override {
     return libndt::Err::eof;
   }
-  bool msg_read_legacy(uint8_t *code, std::string *) noexcept override {
+  bool msg_read_legacy(libndt::MsgType *code, std::string *) noexcept override {
     *code = libndt::msg_test_msg;
     return true;
   }
-  bool msg_write(uint8_t, std::string &&) noexcept override { return true; }
-  bool msg_read(uint8_t *code, std::string *) noexcept override {
+  bool msg_write(libndt::MsgType, std::string &&) noexcept override { return true; }
+  bool msg_read(libndt::MsgType *code, std::string *) noexcept override {
     *code = libndt::msg_login;
     return true;
   }
@@ -871,7 +871,7 @@ class FailEmitResultDuringDownload : public libndt::Client {
     *sock = 17 /* Something "valid" */;
     return libndt::Err::none;
   }
-  bool msg_expect_empty(uint8_t) noexcept override { return true; }
+  bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
   libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
                           timeval *) noexcept override {
     return libndt::Err::none;
@@ -880,12 +880,12 @@ class FailEmitResultDuringDownload : public libndt::Client {
                         libndt::Size *) noexcept override {
     return libndt::Err::eof;
   }
-  bool msg_read_legacy(uint8_t *code, std::string *) noexcept override {
+  bool msg_read_legacy(libndt::MsgType *code, std::string *) noexcept override {
     *code = libndt::msg_test_msg;
     return true;
   }
-  bool msg_write(uint8_t, std::string &&) noexcept override { return true; }
-  bool msg_read(uint8_t *code, std::string *s) noexcept override {
+  bool msg_write(libndt::MsgType, std::string &&) noexcept override { return true; }
+  bool msg_read(libndt::MsgType *code, std::string *s) noexcept override {
     *code = libndt::msg_test_msg;
     *s = "antani-antani";  // Causes emit_result() to fail
     return true;
@@ -908,7 +908,7 @@ class TooManyTestMsgsDuringDownload : public libndt::Client {
     *sock = 17 /* Something "valid" */;
     return libndt::Err::none;
   }
-  bool msg_expect_empty(uint8_t) noexcept override { return true; }
+  bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
   libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
                           timeval *) noexcept override {
     return libndt::Err::none;
@@ -917,12 +917,12 @@ class TooManyTestMsgsDuringDownload : public libndt::Client {
                         libndt::Size *) noexcept override {
     return libndt::Err::eof;
   }
-  bool msg_read_legacy(uint8_t *code, std::string *) noexcept override {
+  bool msg_read_legacy(libndt::MsgType *code, std::string *) noexcept override {
     *code = libndt::msg_test_msg;
     return true;
   }
-  bool msg_write(uint8_t, std::string &&) noexcept override { return true; }
-  bool msg_read(uint8_t *code, std::string *s) noexcept override {
+  bool msg_write(libndt::MsgType, std::string &&) noexcept override { return true; }
+  bool msg_read(libndt::MsgType *code, std::string *s) noexcept override {
     *code = libndt::msg_test_msg;
     *s = "antani:antani";  // Accepted by emit_result()
     return true;
@@ -940,7 +940,7 @@ TEST_CASE("Client::run_download() deals with too many results messages") {
 class FailFirstMsgExpectEmpty : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_expect_empty(uint8_t) noexcept override { return false; }
+  bool msg_expect_empty(libndt::MsgType) noexcept override { return false; }
 };
 
 TEST_CASE(
@@ -952,7 +952,7 @@ TEST_CASE(
 class FailSecondMsgExpectEmpty : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_expect_empty(uint8_t code) noexcept override {
+  bool msg_expect_empty(libndt::MsgType code) noexcept override {
     return code == libndt::msg_test_prepare;
   }
 };
@@ -966,8 +966,8 @@ TEST_CASE(
 class FailMsgWriteDuringMeta : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_expect_empty(uint8_t) noexcept override { return true; }
-  bool msg_write(uint8_t, std::string &&) noexcept override { return false; }
+  bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
+  bool msg_write(libndt::MsgType, std::string &&) noexcept override { return false; }
 };
 
 TEST_CASE("Client::run_meta() deals with Client::msg_write() failure") {
@@ -978,8 +978,8 @@ TEST_CASE("Client::run_meta() deals with Client::msg_write() failure") {
 class FailFinalMsgWriteDuringMeta : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_expect_empty(uint8_t) noexcept override { return true; }
-  bool msg_write(uint8_t, std::string &&s) noexcept override { return s != ""; }
+  bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
+  bool msg_write(libndt::MsgType, std::string &&s) noexcept override { return s != ""; }
 };
 
 TEST_CASE("Client::run_meta() deals with final Client::msg_write() failure") {
@@ -990,10 +990,10 @@ TEST_CASE("Client::run_meta() deals with final Client::msg_write() failure") {
 class FailFinalMsgExpectEmptyDuringMeta : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_expect_empty(uint8_t code) noexcept override {
+  bool msg_expect_empty(libndt::MsgType code) noexcept override {
     return code != libndt::msg_test_finalize;
   }
-  bool msg_write(uint8_t, std::string &&) noexcept override { return true; }
+  bool msg_write(libndt::MsgType, std::string &&) noexcept override { return true; }
 };
 
 TEST_CASE(
@@ -1056,7 +1056,7 @@ class FailSendDuringUpload : public libndt::Client {
     *sock = 17 /* Something "valid" */;
     return libndt::Err::none;
   }
-  bool msg_expect_empty(uint8_t) noexcept override { return true; }
+  bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
   libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
                           timeval *) noexcept override {
     return libndt::Err::none;
@@ -1090,7 +1090,7 @@ class FailMsgExpectDuringUpload : public libndt::Client {
     *sock = 17 /* Something "valid" */;
     return libndt::Err::none;
   }
-  bool msg_expect_empty(uint8_t) noexcept override { return true; }
+  bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
   libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
                           timeval *) noexcept override {
     return libndt::Err::none;
@@ -1099,7 +1099,7 @@ class FailMsgExpectDuringUpload : public libndt::Client {
                         libndt::Size *) noexcept override {
     return libndt::Err::io_error;
   }
-  bool msg_expect(uint8_t, std::string *) noexcept override { return false; }
+  bool msg_expect(libndt::MsgType, std::string *) noexcept override { return false; }
 };
 
 TEST_CASE("Client::run_upload() deals with Client::msg_expect() failure") {
@@ -1118,7 +1118,7 @@ class FailFinalMsgExpectEmptyDuringUpload : public libndt::Client {
     *sock = 17 /* Something "valid" */;
     return libndt::Err::none;
   }
-  bool msg_expect_empty(uint8_t code) noexcept override {
+  bool msg_expect_empty(libndt::MsgType code) noexcept override {
     return code != libndt::msg_test_finalize;
   }
   libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
@@ -1129,7 +1129,7 @@ class FailFinalMsgExpectEmptyDuringUpload : public libndt::Client {
                         libndt::Size *) noexcept override {
     return libndt::Err::io_error;
   }
-  bool msg_expect(uint8_t, std::string *) noexcept override { return true; }
+  bool msg_expect(libndt::MsgType, std::string *) noexcept override { return true; }
 };
 
 TEST_CASE(
@@ -1153,7 +1153,7 @@ TEST_CASE("Client::msg_write_login() deals with invalid protocol") {
 class FailMsgWriteLegacy : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_write_legacy(uint8_t, std::string &&) noexcept override {
+  bool msg_write_legacy(libndt::MsgType, std::string &&) noexcept override {
     return false;
   }
 };
@@ -1167,7 +1167,7 @@ TEST_CASE(
 class ValidatingMsgWriteLegacy : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_write_legacy(uint8_t, std::string &&value) noexcept override {
+  bool msg_write_legacy(libndt::MsgType, std::string &&value) noexcept override {
     auto doc = nlohmann::json::parse(value);
     std::string tests_string = doc.at("tests");
     const char *errstr = nullptr;
@@ -1307,7 +1307,7 @@ TEST_CASE(
 class TooShortVector : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_expect(uint8_t, std::string *) noexcept override { return true; }
+  bool msg_expect(libndt::MsgType, std::string *) noexcept override { return true; }
 };
 
 TEST_CASE("Client::msg_expect_test_prepare() deals with too-short vector") {
@@ -1320,7 +1320,7 @@ TEST_CASE("Client::msg_expect_test_prepare() deals with too-short vector") {
 class InvalidPortVector : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_expect(uint8_t, std::string *s) noexcept override {
+  bool msg_expect(libndt::MsgType, std::string *s) noexcept override {
     *s = "65536";
     return true;
   }
@@ -1336,7 +1336,7 @@ TEST_CASE("Client::msg_expect_test_prepare() deals with invalid port") {
 class InvalidNumFlowsVector : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_expect(uint8_t, std::string *s) noexcept override {
+  bool msg_expect(libndt::MsgType, std::string *s) noexcept override {
     *s = "65530 xx xx xx xx 32";
     return true;
   }
@@ -1361,7 +1361,7 @@ TEST_CASE(
 class NonEmptyMessage : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_expect(uint8_t, std::string *s) noexcept override {
+  bool msg_expect(libndt::MsgType, std::string *s) noexcept override {
     *s = "asd asd asd";
     return true;
   }
@@ -1393,14 +1393,14 @@ TEST_CASE("Client::msg_expect() deals with unexpected message") {
 class FailMsgReadLegacy : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_read_legacy(uint8_t *, std::string *) noexcept override {
+  bool msg_read_legacy(libndt::MsgType *, std::string *) noexcept override {
     return false;
   }
 };
 
 TEST_CASE("Client::msg_read() deals with Client::msg_read_legacy() failure") {
   FailMsgReadLegacy client;
-  uint8_t code = 0;
+  libndt::MsgType code = libndt::MsgType{0};
   std::string s;
   REQUIRE(client.msg_read(&code, &s) == false);
 }
@@ -1408,7 +1408,7 @@ TEST_CASE("Client::msg_read() deals with Client::msg_read_legacy() failure") {
 class ReadInvalidJson : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_read_legacy(uint8_t *, std::string *s) noexcept override {
+  bool msg_read_legacy(libndt::MsgType *, std::string *s) noexcept override {
     *s = "{{{";
     return true;
   }
@@ -1418,7 +1418,7 @@ TEST_CASE("Client::msg_read() deals with invalid JSON") {
   libndt::Settings settings;
   settings.protocol_flags = libndt::protocol_flag_json;
   ReadInvalidJson client{settings};
-  uint8_t code = 0;
+  libndt::MsgType code = libndt::MsgType{0};
   std::string s;
   REQUIRE(client.msg_read(&code, &s) == false);
 }
@@ -1426,7 +1426,7 @@ TEST_CASE("Client::msg_read() deals with invalid JSON") {
 class ReadIncompleteJson : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_read_legacy(uint8_t *, std::string *s) noexcept override {
+  bool msg_read_legacy(libndt::MsgType *, std::string *s) noexcept override {
     *s = "{}";
     return true;
   }
@@ -1436,7 +1436,7 @@ TEST_CASE("Client::msg_read() deals with incomplete JSON") {
   libndt::Settings settings;
   settings.protocol_flags = libndt::protocol_flag_json;
   ReadIncompleteJson client{settings};
-  uint8_t code = 0;
+  libndt::MsgType code = libndt::MsgType{0};
   std::string s;
   REQUIRE(client.msg_read(&code, &s) == false);
 }
@@ -1444,7 +1444,7 @@ TEST_CASE("Client::msg_read() deals with incomplete JSON") {
 class OkayMsgReadLegacy : public libndt::Client {
  public:
   using libndt::Client::Client;
-  bool msg_read_legacy(uint8_t *, std::string *) noexcept override {
+  bool msg_read_legacy(libndt::MsgType *, std::string *) noexcept override {
     return true;
   }
 };
@@ -1454,7 +1454,7 @@ TEST_CASE("Client::msg_read() deals with unknown protocol") {
   // That is, more precisely, a valid but unimplemented proto
   settings.protocol_flags = libndt::protocol_flag_websockets;
   OkayMsgReadLegacy client{settings};
-  uint8_t code = 0;
+  libndt::MsgType code = libndt::MsgType{0};
   std::string s;
   REQUIRE(client.msg_read(&code, &s) == false);
 }
@@ -1467,7 +1467,7 @@ TEST_CASE(
     "header") {
   FailNetxRecvn client;
   client.set_last_system_error(0);
-  uint8_t code = 0;
+  libndt::MsgType code = libndt::MsgType{0};
   std::string s;
   REQUIRE(client.msg_read_legacy(&code, &s) == false);
 }
@@ -1493,7 +1493,7 @@ TEST_CASE(
     "message") {
   FailLargeNetxRecvn client;
   client.set_last_system_error(0);
-  uint8_t code = 0;
+  libndt::MsgType code = libndt::MsgType{0};
   std::string s;
   REQUIRE(client.msg_read_legacy(&code, &s) == false);
 }

--- a/libndt_test.cpp
+++ b/libndt_test.cpp
@@ -1171,11 +1171,11 @@ class ValidatingMsgWriteLegacy : public libndt::Client {
     auto doc = nlohmann::json::parse(value);
     std::string tests_string = doc.at("tests");
     const char *errstr = nullptr;
-    auto tests = this->strtonum(tests_string.c_str(), 0, 256, &errstr);
+    libndt::NettestFlags tests{(uint8_t)this->strtonum(tests_string.c_str(), 0, 256, &errstr)};
     REQUIRE(errstr == nullptr);
-    REQUIRE((tests & libndt::nettest_flag_middlebox) == 0);
-    REQUIRE((tests & libndt::nettest_flag_simple_firewall) == 0);
-    REQUIRE((tests & libndt::nettest_flag_upload_ext) == 0);
+    REQUIRE((tests & libndt::nettest_flag_middlebox) == libndt::NettestFlags{0});
+    REQUIRE((tests & libndt::nettest_flag_simple_firewall) == libndt::NettestFlags{0});
+    REQUIRE((tests & libndt::nettest_flag_upload_ext) == libndt::NettestFlags{0});
     return true;
   }
 };
@@ -1183,7 +1183,7 @@ class ValidatingMsgWriteLegacy : public libndt::Client {
 TEST_CASE("Client::msg_write_login() does not propagate unknown tests ids") {
   libndt::Settings settings;
   settings.protocol_flags = libndt::protocol_flag_json;
-  settings.nettest_flags = 0xff;
+  settings.nettest_flags = libndt::NettestFlags{0xff};
   ValidatingMsgWriteLegacy client{settings};
   REQUIRE(client.msg_write_login(libndt::ndt_version_compat) == true);
 }

--- a/libndt_test.cpp
+++ b/libndt_test.cpp
@@ -692,7 +692,7 @@ class RecvEofDuringDownload : public libndt::Client {
 
 TEST_CASE("Client::run_download() honours max_runtime") {
   libndt::Settings settings;
-  settings.max_runtime = 0;
+  settings.max_runtime = libndt::Timeout{0};
   RecvEofDuringDownload client{settings};
   REQUIRE(client.run_download() == false);
 }
@@ -1074,7 +1074,7 @@ TEST_CASE("Client::run_upload() deals with Client::send() failure") {
 
 TEST_CASE("Client::run_upload() honours max_runtime") {
   libndt::Settings settings;
-  settings.max_runtime = 0;
+  settings.max_runtime = libndt::Timeout{0};
   FailSendDuringUpload client{settings};
   REQUIRE(client.run_upload() == false);
 }


### PR DESCRIPTION
Define suitable typedefs and use them properly. Use a helper class throughout the development of this diff to use the compiler to discover cases where a specific type was used.