### PR TITLE
libndt.hpp: use socklen_t directly

### DIFF
--- a/libndt.hpp
+++ b/libndt.hpp
@@ -104,7 +104,7 @@ using Ssize = int64_t;
 
 using Socket = int64_t;
 
-using SockLen = int;
+using SockLen = socklen_t;
 
 /// Flags to select what protocol should be used.
 using ProtocolFlags = unsigned int;


### PR DESCRIPTION
It seems that (now?) Windows supports `socklen_t`. So use it rather than having a custom type.

This PR just replaces the definition. I'll remove the complexity later.