### PR TITLE
libndt: make sure getsockopt() has correct prototype

### DIFF
--- a/libndt.cpp
+++ b/libndt.cpp
@@ -1645,11 +1645,11 @@ int Client::fcntl3i(Socket s, int cmd, int arg) noexcept {
 }
 #endif
 
-int Client::getsockopt(int socket, int level, int name, void *value,
+int Client::getsockopt(Socket socket, int level, int name, void *value,
                        SockLen *len) noexcept {
   static_assert(sizeof(*len) == sizeof(int), "invalid SockLen size");
-  return ::getsockopt(socket, level, name, AS_OS_OPTION_VALUE(value),
-                      AS_OS_SOCKLEN_STAR(len));
+  return ::getsockopt(AS_OS_SOCKET(socket), level, name,
+                      AS_OS_OPTION_VALUE(value), AS_OS_SOCKLEN_STAR(len));
 }
 
 }  // namespace libndt

--- a/libndt.hpp
+++ b/libndt.hpp
@@ -345,37 +345,66 @@ class Client {
 
   // Dependencies (libc)
 
+  // Access the value of errno in a portable way.
   virtual int get_last_system_error() noexcept;
+
+  // Set the value of errno in a portable way.
   virtual void set_last_system_error(int err) noexcept;
 
+  // getaddrinfo() wrapper that can be mocked in tests.
   virtual int getaddrinfo(const char *domain, const char *port,
                           const addrinfo *hints, addrinfo **res) noexcept;
+
+  // getnameinfo() wrapper that can be mocked in tests.
   virtual int getnameinfo(const sockaddr *sa, SockLen salen, char *host,
                           SockLen hostlen, char *serv, SockLen servlen,
                           int flags) noexcept;
+
+  // freeaddrinfo() wrapper that can be mocked in tests.
   virtual void freeaddrinfo(addrinfo *aip) noexcept;
 
+  // socket() wrapper that can be mocked in tests.
   virtual Socket socket(int domain, int type, int protocol) noexcept;
+
+  // connect() wrapper that can be mocked in tests.
   virtual int connect(Socket fd, const sockaddr *sa, SockLen n) noexcept;
+
+  // recv() wrapper that can be mocked in tests.
   virtual Ssize recv(Socket fd, void *base, Size count) noexcept;
+
+  // send() wrapper that can be mocked in tests.
   virtual Ssize send(Socket fd, const void *base, Size count) noexcept;
-  virtual int shutdown(Socket fd, int how) noexcept;
+
+  // shutdown() wrapper that can be mocked in tests.
+  virtual int shutdown(Socket fd, int shutdown_how) noexcept;
+
+  // Portable wrapper for closing a socket descriptor.
   virtual int closesocket(Socket fd) noexcept;
 
+  // select() wrapper that can be mocked in tests.
   virtual int select(int numfd, fd_set *readset, fd_set *writeset,
                      fd_set *exceptset, timeval *timeout) noexcept;
 
+  // If strtonum() is available, wrapper that can be mocked in tests, else
+  // implementation of strtonum() borrowed from OpenBSD.
   virtual long long strtonum(const char *s, long long minval, long long maxval,
                              const char **err) noexcept;
 
 #ifdef _WIN32
+  // ioctlsocket() wrapper that can be mocked in tests.
   virtual int ioctlsocket(Socket s, long cmd, u_long *argp) noexcept;
 #else
+  // Wrapper for fcntl() taking just two arguments. Good for getting the
+  // currently value of the socket flags.
   virtual int fcntl2(Socket s, int cmd) noexcept;
+
+  // Wrapper for fcntl() taking three arguments with the third argument
+  // being an integer value. Good for setting O_NONBLOCK on a socket.
   virtual int fcntl3i(Socket s, int cmd, int arg) noexcept;
 #endif
 
-  virtual int getsockopt(int socket, int level, int name, void *value,
+  // getsockopt() wrapper that can be mocked in tests.
+  virtual int getsockopt(Socket socket, int level, int name, void *value,
                          SockLen *len) noexcept;
 
  private:


### PR DESCRIPTION
While there add non-doxygen documentation for libc mocks.