### PR TITLE
libndt: make select() more secure

### DIFF
--- a/libndt.cpp
+++ b/libndt.cpp
@@ -1529,13 +1529,18 @@ Err Client::netx_select(std::vector<Socket> wantread, std::vector<Socket> wantwr
       if (!add_descriptor(fd, &readset)) {
         return Err::invalid_argument;
       }
-      maxfd = std::max(maxfd, fd);
+      maxfd = (std::max)(maxfd, fd);
     }
     for (auto fd : wantwrite) {
       if (!add_descriptor(fd, &writeset)) {
         return Err::invalid_argument;
       }
-      maxfd = std::max(maxfd, fd);
+      maxfd = (std::max)(maxfd, fd);
+    }
+    assert(maxfd >= -1);
+    if (maxfd == -1) {
+      EMIT_WARNING("netx_select: you did not pass me any descriptor");
+      return Err::invalid_argument;
     }
     sys_set_last_error(0);
     // Implementation note: cast to `int` is safe because on Windows the first

--- a/libndt.cpp
+++ b/libndt.cpp
@@ -1484,6 +1484,12 @@ Err Client::netx_wait_writeable(Socket fd, timeval tv) noexcept {
 Err Client::netx_select(std::vector<Socket> wantread, std::vector<Socket> wantwrite,
                         timeval tv, std::vector<Socket> *readable,
                         std::vector<Socket> *writeable) noexcept {
+  if (readable != nullptr) {
+    readable->clear();
+  }
+  if (writeable != nullptr) {
+    writeable->clear();
+  }
   for (;;) {
     // add_descriptor() safely adds @p fd to @p set.
 #ifdef _WIN32

--- a/libndt.hpp
+++ b/libndt.hpp
@@ -333,8 +333,14 @@ class Client {
 
   virtual Err netx_setnonblocking(Socket fd, bool enable) noexcept;
 
-  virtual Err netx_select(int numfd, fd_set *readset, fd_set *writeset,
-                          fd_set *exceptset, timeval *timeout) noexcept;
+  virtual Err netx_wait_readable(Socket, timeval timeout) noexcept;
+
+  virtual Err netx_wait_writeable(Socket, timeval timeout) noexcept;
+
+  virtual Err netx_select(std::vector<Socket> wantread,
+                          std::vector<Socket> wantwrite, timeval timeout,
+                          std::vector<Socket> *readable,
+                          std::vector<Socket> *writeable) noexcept;
 
   // Dependencies (cURL)
 
@@ -428,6 +434,7 @@ enum class Err {
   operation_in_progress,
   operation_would_block,
   timed_out,
+  value_too_large,
   eof,
   ai_generic,
   ai_again,

--- a/libndt.hpp
+++ b/libndt.hpp
@@ -306,37 +306,53 @@ class Client {
   virtual bool msg_read_legacy(MsgType *code, std::string *msg) noexcept;
 
   // Networking layer
+  // ````````````````
+  //
+  // This section contains network functionality used to implement NDT.
 
+  // Connect to @p hostname and @port possibly using SOCKSv5.
   virtual Err netx_maybesocks5h_dial(const std::string &hostname,
                                      const std::string &port,
                                      Socket *sock) noexcept;
 
+  // Map errno code into a Err value.
   static Err netx_map_errno(int ec) noexcept;
 
+  // Map getaddrinfo return value into a Err value.
   Err netx_map_eai(int ec) noexcept;
 
+  // Connect to @p hostname and @p port.
   virtual Err netx_dial(const std::string &hostname, const std::string &port,
                         Socket *sock) noexcept;
 
+  // Receive from the network.
   virtual Err netx_recv(Socket fd, void *base, Size count,
                         Size *actual) noexcept;
 
+  // Receive exactly N bytes from the network.
   virtual Err netx_recvn(Socket fd, void *base, Size count) noexcept;
 
+  // Send data to the network.
   virtual Err netx_send(Socket fd, const void *base, Size count,
                         Size *actual) noexcept;
 
+  // Send exactly N bytes to the network.
   virtual Err netx_sendn(Socket fd, const void *base, Size count) noexcept;
 
+  // Resolve hostname into a list of IP addresses.
   virtual Err netx_resolve(const std::string &hostname,
                            std::vector<std::string> *addrs) noexcept;
 
+  // Set socket non blocking.
   virtual Err netx_setnonblocking(Socket fd, bool enable) noexcept;
 
+  // Pauses until the socket becomes readable.
   virtual Err netx_wait_readable(Socket, timeval timeout) noexcept;
 
+  // Pauses until the socket becomes writeable.
   virtual Err netx_wait_writeable(Socket, timeval timeout) noexcept;
 
+  // Simplified wrapper for select that deals with EINTR and FD_SETSIZE.
   virtual Err netx_select(std::vector<Socket> wantread,
                           std::vector<Socket> wantwrite, timeval timeout,
                           std::vector<Socket> *readable,
@@ -350,6 +366,9 @@ class Client {
                                  std::string *body) noexcept;
 
   // Dependencies (system)
+  // `````````````````````
+  //
+  // This section contains wrappers for system calls used in regress tests.
 
   // Access the value of errno in a portable way.
   virtual int sys_get_last_error() noexcept;

--- a/libndt_test.cpp
+++ b/libndt_test.cpp
@@ -499,8 +499,10 @@ TEST_CASE("Client::recv_results_and_logout() deals with too many results") {
 class NetxSelectHardFailure : public libndt::Client {
  public:
   using libndt::Client::Client;
-  libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
-                          timeval *) noexcept override {
+  libndt::Err netx_select(std::vector<libndt::Socket>,
+                          std::vector<libndt::Socket>, timeval,
+                          std::vector<libndt::Socket> *,
+                          std::vector<libndt::Socket> *) noexcept override {
     return libndt::Err::io_error;
   }
 };
@@ -514,8 +516,10 @@ TEST_CASE(
 class NetxSelectTimeout : public libndt::Client {
  public:
   using libndt::Client::Client;
-  libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
-                          timeval *) noexcept override {
+  libndt::Err netx_select(std::vector<libndt::Socket>,
+                          std::vector<libndt::Socket>, timeval,
+                          std::vector<libndt::Socket> *,
+                          std::vector<libndt::Socket> *) noexcept override {
     return libndt::Err::timed_out;
   }
 };
@@ -528,8 +532,10 @@ TEST_CASE("Client::wait_close() deals with Client::netx_select() timeout") {
 class NotEofAfterGoodNetxSelect : public libndt::Client {
  public:
   using libndt::Client::Client;
-  libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
-                          timeval *) noexcept override {
+  libndt::Err netx_select(std::vector<libndt::Socket>,
+                          std::vector<libndt::Socket>, timeval,
+                          std::vector<libndt::Socket> *,
+                          std::vector<libndt::Socket> *) noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recv(libndt::Socket, void *, libndt::Size,
@@ -548,8 +554,10 @@ TEST_CASE(
 class SuccessAfterGoodNetxSelect : public libndt::Client {
  public:
   using libndt::Client::Client;
-  libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
-                          timeval *) noexcept override {
+  libndt::Err netx_select(std::vector<libndt::Socket>,
+                          std::vector<libndt::Socket>, timeval,
+                          std::vector<libndt::Socket> *,
+                          std::vector<libndt::Socket> *) noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recv(libndt::Socket, void *, libndt::Size size,
@@ -634,8 +642,10 @@ class FailNetxSelectDuringDownload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
-                          timeval *) noexcept override {
+  libndt::Err netx_select(std::vector<libndt::Socket>,
+                          std::vector<libndt::Socket>, timeval,
+                          std::vector<libndt::Socket> *,
+                          std::vector<libndt::Socket> *) noexcept override {
     return libndt::Err::io_error;
   }
 };
@@ -657,8 +667,10 @@ class FailRecvDuringDownload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
-                          timeval *) noexcept override {
+  libndt::Err netx_select(std::vector<libndt::Socket>,
+                          std::vector<libndt::Socket>, timeval,
+                          std::vector<libndt::Socket> *,
+                          std::vector<libndt::Socket> *) noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recv(libndt::Socket, void *, libndt::Size,
@@ -684,8 +696,10 @@ class RecvEofDuringDownload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
-                          timeval *) noexcept override {
+  libndt::Err netx_select(std::vector<libndt::Socket>,
+                          std::vector<libndt::Socket>, timeval,
+                          std::vector<libndt::Socket> *,
+                          std::vector<libndt::Socket> *) noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recv(libndt::Socket, void *, libndt::Size,
@@ -713,8 +727,10 @@ class FailMsgReadLegacyDuringDownload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
-                          timeval *) noexcept override {
+  libndt::Err netx_select(std::vector<libndt::Socket>,
+                          std::vector<libndt::Socket>, timeval,
+                          std::vector<libndt::Socket> *,
+                          std::vector<libndt::Socket> *) noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recv(libndt::Socket, void *, libndt::Size,
@@ -744,8 +760,10 @@ class RecvNonTestMsgDuringDownload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
-                          timeval *) noexcept override {
+  libndt::Err netx_select(std::vector<libndt::Socket>,
+                          std::vector<libndt::Socket>, timeval,
+                          std::vector<libndt::Socket> *,
+                          std::vector<libndt::Socket> *) noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recv(libndt::Socket, void *, libndt::Size,
@@ -775,8 +793,10 @@ class FailMsgWriteDuringDownload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
-                          timeval *) noexcept override {
+  libndt::Err netx_select(std::vector<libndt::Socket>,
+                          std::vector<libndt::Socket>, timeval,
+                          std::vector<libndt::Socket> *,
+                          std::vector<libndt::Socket> *) noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recv(libndt::Socket, void *, libndt::Size,
@@ -809,8 +829,10 @@ class FailMsgReadDuringDownload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
-                          timeval *) noexcept override {
+  libndt::Err netx_select(std::vector<libndt::Socket>,
+                          std::vector<libndt::Socket>, timeval,
+                          std::vector<libndt::Socket> *,
+                          std::vector<libndt::Socket> *) noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recv(libndt::Socket, void *, libndt::Size,
@@ -846,8 +868,10 @@ class RecvNonTestOrLogoutMsgDuringDownload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
-                          timeval *) noexcept override {
+  libndt::Err netx_select(std::vector<libndt::Socket>,
+                          std::vector<libndt::Socket>, timeval,
+                          std::vector<libndt::Socket> *,
+                          std::vector<libndt::Socket> *) noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recv(libndt::Socket, void *, libndt::Size,
@@ -884,8 +908,10 @@ class FailEmitResultDuringDownload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
-                          timeval *) noexcept override {
+  libndt::Err netx_select(std::vector<libndt::Socket>,
+                          std::vector<libndt::Socket>, timeval,
+                          std::vector<libndt::Socket> *,
+                          std::vector<libndt::Socket> *) noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recv(libndt::Socket, void *, libndt::Size,
@@ -923,8 +949,10 @@ class TooManyTestMsgsDuringDownload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
-                          timeval *) noexcept override {
+  libndt::Err netx_select(std::vector<libndt::Socket>,
+                          std::vector<libndt::Socket>, timeval,
+                          std::vector<libndt::Socket> *,
+                          std::vector<libndt::Socket> *) noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recv(libndt::Socket, void *, libndt::Size,
@@ -1079,8 +1107,10 @@ class FailSendDuringUpload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
-                          timeval *) noexcept override {
+  libndt::Err netx_select(std::vector<libndt::Socket>,
+                          std::vector<libndt::Socket>, timeval,
+                          std::vector<libndt::Socket> *,
+                          std::vector<libndt::Socket> *) noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_send(libndt::Socket, const void *, libndt::Size,
@@ -1113,8 +1143,10 @@ class FailMsgExpectDuringUpload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
-                          timeval *) noexcept override {
+  libndt::Err netx_select(std::vector<libndt::Socket>,
+                          std::vector<libndt::Socket>, timeval,
+                          std::vector<libndt::Socket> *,
+                          std::vector<libndt::Socket> *) noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_send(libndt::Socket, const void *, libndt::Size,
@@ -1145,8 +1177,10 @@ class FailFinalMsgExpectEmptyDuringUpload : public libndt::Client {
   bool msg_expect_empty(libndt::MsgType code) noexcept override {
     return code != libndt::msg_test_finalize;
   }
-  libndt::Err netx_select(int, fd_set *, fd_set *, fd_set *,
-                          timeval *) noexcept override {
+  libndt::Err netx_select(std::vector<libndt::Socket>,
+                          std::vector<libndt::Socket>, timeval,
+                          std::vector<libndt::Socket> *,
+                          std::vector<libndt::Socket> *) noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_send(libndt::Socket, const void *, libndt::Size,
@@ -2592,13 +2626,12 @@ class InterruptSelect : public libndt::Client {
 
 TEST_CASE("Client::netx_select() deals with EINTR") {
   libndt::Socket maxfd = 17;
+  std::vector<libndt::Socket> wantread;
+  wantread.push_back(maxfd);
   InterruptSelect client;
-  fd_set readset;
-  FD_ZERO(&readset);
-  FD_SET(maxfd, &readset);
   timeval tv{};
   REQUIRE(client.netx_select(  //
-              (int)maxfd + 1, &readset, nullptr, nullptr, &tv) ==
+              std::move(wantread), {}, tv, nullptr, nullptr) ==
           libndt::Err::io_error);
   REQUIRE(client.count == 2);
 }
@@ -2616,16 +2649,12 @@ class TimeoutSelect : public libndt::Client {
 
 TEST_CASE("Client::netx_select() deals with timeout") {
   libndt::Socket maxfd = 17;
+  std::vector<libndt::Socket> wantread;
+  wantread.push_back(maxfd);
   TimeoutSelect client;
-  fd_set readset;
-  FD_ZERO(&readset);
-#ifdef _WIN32
-  FD_SET((SOCKET)maxfd, &readset);
-#else
-  FD_SET(maxfd, &readset);
-#endif
-  REQUIRE(client.netx_select((int)maxfd + 1, &readset, nullptr, nullptr,
-                             nullptr) == libndt::Err::timed_out);
+  REQUIRE(client.netx_select(  //
+              std::move(wantread), {}, {}, nullptr, nullptr) ==
+          libndt::Err::timed_out);
 }
 
 // Client::query_mlabns_curl() tests


### PR DESCRIPTION
There is the issue that in principle select() may cause segfaults
if one sets more than FD_SETSIZE file descriptors.

The code checking that we were correctly using select() did not
perform these checks and was messy.

So, refactor this code into a simpler to use interface and ensure
that all FD_SETSIZE checks are performed in the right place.