### PR TITLE
libndt: handle types in a more correct way

### DIFF
--- a/libndt.cpp
+++ b/libndt.cpp
@@ -1504,7 +1504,7 @@ Err Client::netx_resolve(const std::string &hostname,
     char address[NI_MAXHOST], port[NI_MAXSERV];
     // The following casts from `size_t` to `socklen_t` are safe for sure
     // because NI_MAXHOST and NI_MAXSERV are small values. To make sure this
-    // assumption is correct, deploy the following static cast. Here I am
+    // assumption is correct, deploy the following static assertion. Here I am
     // using INT_MAX as upper bound since socklen_t SHOULD be `int`.
     static_assert(sizeof(address) <= INT_MAX && sizeof(port) <= INT_MAX,
                   "Wrong assumption about NI_MAXHOST or NI_MAXSERV");

--- a/libndt.cpp
+++ b/libndt.cpp
@@ -1504,7 +1504,8 @@ Err Client::netx_resolve(const std::string &hostname,
     char address[NI_MAXHOST], port[NI_MAXSERV];
     // The following casts from `size_t` to `socklen_t` are safe for sure
     // because NI_MAXHOST and NI_MAXSERV are small values. To make sure this
-    // assumption is correct, deploy the following static cast.
+    // assumption is correct, deploy the following static cast. Here I am
+    // using INT_MAX as upper bound since socklen_t SHOULD be `int`.
     static_assert(sizeof(address) <= INT_MAX && sizeof(port) <= INT_MAX,
                   "Wrong assumption about NI_MAXHOST or NI_MAXSERV");
     // Additionally on Windows there's a cast from size_t to socklen_t that

--- a/libndt.cpp
+++ b/libndt.cpp
@@ -1311,7 +1311,7 @@ Err Client::netx_dial(const std::string &hostname, const std::string &port,
         continue;
       }
       // While on Unix ai_addrlen is socklen_t, it's size_t on Windows. Just
-      // for the sake of corretness, add a check that ensures that the size has
+      // for the sake of correctness, add a check that ensures that the size has
       // a reasonable value before casting to socklen_t. My understanding is
       // that size_t is `ULONG_PTR` while socklen_t is most likely `int`.
 #ifdef _WIN32

--- a/libndt.hpp
+++ b/libndt.hpp
@@ -104,9 +104,19 @@ constexpr Size SizeMax = UINT64_MAX;
 
 using Ssize = int64_t;
 
-using Socket = int64_t;
+#ifdef _WIN32
+using Socket = SOCKET;
+#else
+using Socket = int;
+#endif
 
-using SockLen = socklen_t;
+constexpr bool is_socket_valid(Socket s) noexcept {
+#ifdef _WIN32
+  return s != INVALID_SOCKET;
+#else
+  return s >= 0;
+#endif
+}
 
 /// Flags to select what protocol should be used.
 using ProtocolFlags = unsigned int;
@@ -391,8 +401,8 @@ class Client {
                               const addrinfo *hints, addrinfo **res) noexcept;
 
   // getnameinfo() wrapper that can be mocked in tests.
-  virtual int sys_getnameinfo(const sockaddr *sa, SockLen salen, char *host,
-                              SockLen hostlen, char *serv, SockLen servlen,
+  virtual int sys_getnameinfo(const sockaddr *sa, socklen_t salen, char *host,
+                              socklen_t hostlen, char *serv, socklen_t servlen,
                               int flags) noexcept;
 
   // freeaddrinfo() wrapper that can be mocked in tests.
@@ -402,7 +412,7 @@ class Client {
   virtual Socket sys_socket(int domain, int type, int protocol) noexcept;
 
   // connect() wrapper that can be mocked in tests.
-  virtual int sys_connect(Socket fd, const sockaddr *sa, SockLen n) noexcept;
+  virtual int sys_connect(Socket fd, const sockaddr *sa, socklen_t n) noexcept;
 
   // recv() wrapper that can be mocked in tests.
   virtual Ssize sys_recv(Socket fd, void *base, Size count) noexcept;
@@ -440,7 +450,7 @@ class Client {
 
   // getsockopt() wrapper that can be mocked in tests.
   virtual int sys_getsockopt(Socket socket, int level, int name, void *value,
-                             SockLen *len) noexcept;
+                             socklen_t *len) noexcept;
 
  private:
   class Impl;


### PR DESCRIPTION
1. use the platform native definition of socket and introduce
   a constexpr function telling us whether a socket is valid so
   that we can remove some casting

2. since socklen_t is (now?) available on Windows, just use
   it rather than having our own SockLen type

3. while there, get rid of unused macros