### PR TITLE
README.md: mention required dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,9 @@ We use `cmake`. If you install `OpenSSL` library and headers, libndt will
 have support for TLS based tests. If you install `cURL` library and headers,
 libndt will perform server auto-discovery using the `mlab-ns` service.
 
-(To see the exact dependencies required on Debian, you can see the content
-of the [Dockerfile](
-https://github.com/measurement-kit/docker-ci/blob/master/debian/Dockerfile)
-that we use to test libndt in Travis-CI.)
+(To see the exact dependencies required on Debian, please check out the
+[Dockerfile](https://github.com/measurement-kit/docker-ci/blob/master/debian/Dockerfile)
+used when testing in Travis-CI.)
 
 ```
 cmake .

--- a/README.md
+++ b/README.md
@@ -30,8 +30,17 @@ git clone --recursive https://github.com/measurement-kit/libndt
 
 ## Build and test
 
+We use `cmake`. If you install `OpenSSL` library and headers, libndt will
+have support for TLS based tests. If you install `cURL` library and headers,
+libndt will perform server auto-discovery using the `mlab-ns` service.
+
+(To see the exact dependencies required on Debian, you can see the content
+of the [Dockerfile](.ci/docker/debian/Dockerfile) that we use to test
+libndt in Travis-CI.)
+
 ```
 cmake .
 cmake --build .
 ctest -a --output-on-failure .
+./libndt-client
 ```

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ have support for TLS based tests. If you install `cURL` library and headers,
 libndt will perform server auto-discovery using the `mlab-ns` service.
 
 (To see the exact dependencies required on Debian, you can see the content
-of the [Dockerfile](.ci/docker/debian/Dockerfile) that we use to test
-libndt in Travis-CI.)
+of the [Dockerfile](
+https://github.com/measurement-kit/docker-ci/blob/master/debian/Dockerfile)
+that we use to test libndt in Travis-CI.)
 
 ```
 cmake .


### PR DESCRIPTION
Understood that this was a good idea while helping @evfirerob to install libndt on his own system.