### PR TITLE
Enforce constness in s2c and c2s threads

### DIFF
--- a/libndt.hpp
+++ b/libndt.hpp
@@ -400,17 +400,17 @@ class Client {
   /// Called when a warning message is emitted. The default behavior is to write
   /// the warning onto the `std::clog` standard stream. \warning This method
   /// could be called from a different thread context.
-  virtual void on_warning(const std::string &s);
+  virtual void on_warning(const std::string &s) const;
 
   /// Called when an informational message is emitted. The default behavior is
   /// to write the message onto the `std::clog` standard stream. \warning This method
   /// could be called from a different thread context.
-  virtual void on_info(const std::string &s);
+  virtual void on_info(const std::string &s) const;
 
   /// Called when a debug message is emitted. The default behavior is
   /// to write the message onto the `std::clog` standard stream. \warning This method
   /// could be called from a different thread context.
-  virtual void on_debug(const std::string &s);
+  virtual void on_debug(const std::string &s) const;
 
   /// Called to inform you about the measured speed. The default behavior is
   /// to write the provided information as an info message. @param tid is either
@@ -535,19 +535,19 @@ class Client {
   // Send @p count bytes from @p base over @p sock as a frame whose first byte
   // @p first_byte should contain the opcode and possibly the FIN flag.
   virtual Err ws_send_frame(Socket sock, uint8_t first_byte, uint8_t *base,
-                            Size count) noexcept;
+                            Size count) const noexcept;
 
   // Receive a frame from @p sock. Puts the opcode in @p *opcode. Puts whether
   // there is a FIN flag in @p *fin. The buffer starts at @p base and it
   // contains @p total bytes. Puts in @p *count the actual number of bytes
   // in the message. @return The error that occurred or Err::none.
   Err ws_recv_any_frame(Socket sock, uint8_t *opcode, bool *fin, uint8_t *base,
-                        Size total, Size *count) noexcept;
+                        Size total, Size *count) const noexcept;
 
   // Receive a frame. Automatically and transparently responds to PING, ignores
   // PONG, and handles CLOSE frames. Arguments like ws_recv_any_frame().
   Err ws_recv_frame(Socket sock, uint8_t *opcode, bool *fin, uint8_t *base,
-                    Size total, Size *count) noexcept;
+                    Size total, Size *count) const noexcept;
 
   // Receive a message consisting of one or more frames. Transparently handles
   // PING and PONG frames. Handles CLOSE frames. @param sock is the socket to
@@ -556,7 +556,7 @@ class Client {
   // count contains the actual message size. @return An error on failure or
   // Err::none in case of success.
   Err ws_recvmsg(Socket sock, uint8_t *opcode, uint8_t *base, Size total,
-                 Size *count) noexcept;
+                 Size *count) const noexcept;
 
   // Networking layer
   // ````````````````
@@ -610,25 +610,26 @@ class Client {
 
   // Receive from the network.
   virtual Err netx_recv(Socket fd, void *base, Size count,
-                        Size *actual) noexcept;
+                        Size *actual) const noexcept;
 
   // Receive from the network without blocking.
   virtual Err netx_recv_nonblocking(Socket fd, void *base, Size count,
-                                    Size *actual) noexcept;
+                                    Size *actual) const noexcept;
 
   // Receive exactly N bytes from the network.
-  virtual Err netx_recvn(Socket fd, void *base, Size count) noexcept;
+  virtual Err netx_recvn(Socket fd, void *base, Size count) const noexcept;
 
   // Send data to the network.
   virtual Err netx_send(Socket fd, const void *base, Size count,
-                        Size *actual) noexcept;
+                        Size *actual) const noexcept;
 
   // Send to the network without blocking.
   virtual Err netx_send_nonblocking(Socket fd, const void *base, Size count,
-                                    Size *actual) noexcept;
+                                    Size *actual) const noexcept;
 
   // Send exactly N bytes to the network.
-  virtual Err netx_sendn(Socket fd, const void *base, Size count) noexcept;
+  virtual Err netx_sendn(
+    Socket fd, const void *base, Size count) const noexcept;
 
   // Resolve hostname into a list of IP addresses.
   virtual Err netx_resolve(const std::string &hostname,
@@ -638,13 +639,14 @@ class Client {
   virtual Err netx_setnonblocking(Socket fd, bool enable) noexcept;
 
   // Pauses until the socket becomes readable.
-  virtual Err netx_wait_readable(Socket, Timeout timeout) noexcept;
+  virtual Err netx_wait_readable(Socket, Timeout timeout) const noexcept;
 
   // Pauses until the socket becomes writeable.
-  virtual Err netx_wait_writeable(Socket, Timeout timeout) noexcept;
+  virtual Err netx_wait_writeable(Socket, Timeout timeout) const noexcept;
 
   // Main function for dealing with I/O patterned after poll(2).
-  virtual Err netx_poll(std::vector<pollfd> *fds, int timeout_msec) noexcept;
+  virtual Err netx_poll(
+    std::vector<pollfd> *fds, int timeout_msec) const noexcept;
 
   // Shutdown both ends of a socket.
   virtual Err netx_shutdown_both(Socket fd) noexcept;
@@ -701,10 +703,10 @@ class Client {
   // This section contains wrappers for system calls used in regress tests.
 
   // Access the value of errno in a portable way.
-  virtual int sys_get_last_error() noexcept;
+  virtual int sys_get_last_error() const noexcept;
 
   // Set the value of errno in a portable way.
-  virtual void sys_set_last_error(int err) noexcept;
+  virtual void sys_set_last_error(int err) const noexcept;
 
   // getaddrinfo() wrapper that can be mocked in tests.
   virtual int sys_getaddrinfo(const char *domain, const char *port,
@@ -725,10 +727,11 @@ class Client {
   virtual int sys_connect(Socket fd, const sockaddr *sa, socklen_t n) noexcept;
 
   // recv() wrapper that can be mocked in tests.
-  virtual Ssize sys_recv(Socket fd, void *base, Size count) noexcept;
+  virtual Ssize sys_recv(Socket fd, void *base, Size count) const noexcept;
 
   // send() wrapper that can be mocked in tests.
-  virtual Ssize sys_send(Socket fd, const void *base, Size count) noexcept;
+  virtual Ssize sys_send(
+    Socket fd, const void *base, Size count) const noexcept;
 
   // shutdown() wrapper that can be mocked in tests.
   virtual int sys_shutdown(Socket fd, int shutdown_how) noexcept;
@@ -738,9 +741,9 @@ class Client {
 
   // poll() wrapper that can be mocked in tests.
 #ifdef _WIN32
-  virtual int sys_poll(LPWSAPOLLFD fds, ULONG nfds, INT timeout) noexcept;
+  virtual int sys_poll(LPWSAPOLLFD fds, ULONG nfds, INT timeout) const noexcept;
 #else
-  virtual int sys_poll(pollfd *fds, nfds_t nfds, int timeout) noexcept;
+  virtual int sys_poll(pollfd *fds, nfds_t nfds, int timeout) const noexcept;
 #endif
 
   // If strtonum() is available, wrapper that can be mocked in tests, else
@@ -1197,13 +1200,15 @@ bool Client::run() noexcept {
   return false;
 }
 
-void Client::on_warning(const std::string &msg) {
+void Client::on_warning(const std::string &msg) const {
   std::clog << "[!] " << msg << std::endl;
 }
 
-void Client::on_info(const std::string &msg) { std::clog << msg << std::endl; }
+void Client::on_info(const std::string &msg) const {
+  std::clog << msg << std::endl;
+}
 
-void Client::on_debug(const std::string &msg) {
+void Client::on_debug(const std::string &msg) const {
   std::clog << "[D] " << msg << std::endl;
 }
 
@@ -2224,7 +2229,7 @@ Err Client::ws_handshake(Socket fd, std::string port, uint64_t ws_flags,
 }
 
 Err Client::ws_send_frame(Socket sock, uint8_t first_byte, uint8_t *base,
-                          Size count) noexcept {
+                          Size count) const noexcept {
   // TODO(bassosimone): perhaps move the RNG into Client?
   constexpr Size mask_size = 4;
   uint8_t mask[mask_size] = {};
@@ -2331,7 +2336,7 @@ Err Client::ws_send_frame(Socket sock, uint8_t first_byte, uint8_t *base,
 }
 
 Err Client::ws_recv_any_frame(Socket sock, uint8_t *opcode, bool *fin,
-                              uint8_t *base, Size total, Size *count) noexcept {
+      uint8_t *base, Size total, Size *count) const noexcept {
   if (opcode == nullptr || fin == nullptr || count == nullptr) {
     LIBNDT_EMIT_WARNING("ws_recv_any_frame: passed invalid return arguments");
     return Err::invalid_argument;
@@ -2486,7 +2491,7 @@ Err Client::ws_recv_any_frame(Socket sock, uint8_t *opcode, bool *fin,
 }
 
 Err Client::ws_recv_frame(Socket sock, uint8_t *opcode, bool *fin,
-                          uint8_t *base, Size total, Size *count) noexcept {
+      uint8_t *base, Size total, Size *count) const noexcept {
   // "Control frames (see Section 5.5) MAY be injected in the middle of
   // a fragmented message.  Control frames themselves MUST NOT be fragmented."
   //    -- RFC6455 Section 5.4.
@@ -2545,7 +2550,7 @@ again:
 
 Err Client::ws_recvmsg(  //
     Socket sock, uint8_t *opcode, uint8_t *base, Size total,
-    Size *count) noexcept {
+    Size *count) const noexcept {
   // General remark from RFC6455 Sect. 5.4: "[I]n absence of extensions, senders
   // and receivers must not depend on [...] specific frame boundaries."
   //
@@ -2773,7 +2778,7 @@ static BIO_METHOD *libndt_bio_method() noexcept {
 // } - - - END BIO IMPLEMENTATION - - -
 
 // Common function to map OpenSSL errors to Err.
-static Err map_ssl_error(Client *client, SSL *ssl, int ret) noexcept {
+static Err map_ssl_error(const Client *client, SSL *ssl, int ret) noexcept {
   auto reason = ::SSL_get_error(ssl, ret);
   switch (reason) {
     case SSL_ERROR_NONE:
@@ -3366,7 +3371,7 @@ Err Client::netx_dial(const std::string &hostname, const std::string &port,
 #undef CONNECT_IN_PROGRESS  // Tidy
 
 Err Client::netx_recv(Socket fd, void *base, Size count,
-                      Size *actual) noexcept {
+                      Size *actual) const noexcept {
   auto err = Err::none;
 again:
   err = netx_recv_nonblocking(fd, base, count, actual);
@@ -3387,7 +3392,7 @@ again:
 }
 
 Err Client::netx_recv_nonblocking(Socket fd, void *base, Size count,
-                                  Size *actual) noexcept {
+                                  Size *actual) const noexcept {
   assert(base != nullptr && actual != nullptr);
   *actual = 0;
   if (count <= 0) {
@@ -3429,7 +3434,7 @@ Err Client::netx_recv_nonblocking(Socket fd, void *base, Size count,
   return Err::none;
 }
 
-Err Client::netx_recvn(Socket fd, void *base, Size count) noexcept {
+Err Client::netx_recvn(Socket fd, void *base, Size count) const noexcept {
   Size off = 0;
   while (off < count) {
     Size n = 0;
@@ -3449,7 +3454,7 @@ Err Client::netx_recvn(Socket fd, void *base, Size count) noexcept {
 }
 
 Err Client::netx_send(Socket fd, const void *base, Size count,
-                      Size *actual) noexcept {
+                      Size *actual) const noexcept {
   auto err = Err::none;
 again:
   err = netx_send_nonblocking(fd, base, count, actual);
@@ -3470,7 +3475,7 @@ again:
 }
 
 Err Client::netx_send_nonblocking(Socket fd, const void *base, Size count,
-                                  Size *actual) noexcept {
+                                  Size *actual) const noexcept {
   assert(base != nullptr && actual != nullptr);
   *actual = 0;
   if (count <= 0) {
@@ -3514,7 +3519,7 @@ Err Client::netx_send_nonblocking(Socket fd, const void *base, Size count,
   return Err::none;
 }
 
-Err Client::netx_sendn(Socket fd, const void *base, Size count) noexcept {
+Err Client::netx_sendn(Socket fd, const void *base, Size count) const noexcept {
   Size off = 0;
   while (off < count) {
     Size n = 0;
@@ -3613,7 +3618,7 @@ Err Client::netx_setnonblocking(Socket fd, bool enable) noexcept {
   return Err::none;
 }
 
-static Err netx_wait(Client *client, Socket fd, Timeout timeout,
+static Err netx_wait(const Client *client, Socket fd, Timeout timeout,
                      short expected_events) noexcept {
   pollfd pfd{};
   pfd.fd = fd;
@@ -3637,15 +3642,16 @@ static Err netx_wait(Client *client, Socket fd, Timeout timeout,
   return err;
 }
 
-Err Client::netx_wait_readable(Socket fd, Timeout timeout) noexcept {
+Err Client::netx_wait_readable(Socket fd, Timeout timeout) const noexcept {
   return netx_wait(this, fd, timeout, POLLIN);
 }
 
-Err Client::netx_wait_writeable(Socket fd, Timeout timeout) noexcept {
+Err Client::netx_wait_writeable(Socket fd, Timeout timeout) const noexcept {
   return netx_wait(this, fd, timeout, POLLOUT);
 }
 
-Err Client::netx_poll(std::vector<pollfd> *pfds, int timeout_msec) noexcept {
+Err Client::netx_poll(
+      std::vector<pollfd> *pfds, int timeout_msec) const noexcept {
   if (pfds == nullptr) {
     LIBNDT_EMIT_WARNING("netx_poll: passed a null vector of descriptors");
     return Err::invalid_argument;
@@ -3885,7 +3891,7 @@ Verbosity Client::get_verbosity() const noexcept {
 #define LIBNDT_AS_OS_OPTION_VALUE(x) ((void *)x)
 #endif
 
-int Client::sys_get_last_error() noexcept {
+int Client::sys_get_last_error() const noexcept {
 #ifdef _WIN32
   return GetLastError();
 #else
@@ -3893,7 +3899,7 @@ int Client::sys_get_last_error() noexcept {
 #endif
 }
 
-void Client::sys_set_last_error(int err) noexcept {
+void Client::sys_set_last_error(int err) const noexcept {
 #ifdef _WIN32
   SetLastError(err);
 #else
@@ -3922,7 +3928,7 @@ int Client::sys_connect(Socket fd, const sockaddr *sa, socklen_t len) noexcept {
   return ::connect(fd, sa, len);
 }
 
-Ssize Client::sys_recv(Socket fd, void *base, Size count) noexcept {
+Ssize Client::sys_recv(Socket fd, void *base, Size count) const noexcept {
   if (count > LIBNDT_OS_SSIZE_MAX) {
     sys_set_last_error(OS_EINVAL);
     return -1;
@@ -3935,7 +3941,7 @@ Ssize Client::sys_recv(Socket fd, void *base, Size count) noexcept {
   return (Ssize)::recv(fd, LIBNDT_AS_OS_BUFFER(base), LIBNDT_AS_OS_BUFFER_LEN(count), flags);
 }
 
-Ssize Client::sys_send(Socket fd, const void *base, Size count) noexcept {
+Ssize Client::sys_send(Socket fd, const void *base, Size count) const noexcept {
   if (count > LIBNDT_OS_SSIZE_MAX) {
     sys_set_last_error(OS_EINVAL);
     return -1;
@@ -3961,11 +3967,11 @@ int Client::sys_closesocket(Socket fd) noexcept {
 }
 
 #ifdef _WIN32
-int Client::sys_poll(LPWSAPOLLFD fds, ULONG nfds, INT timeout) noexcept {
+int Client::sys_poll(LPWSAPOLLFD fds, ULONG nfds, INT timeout) const noexcept {
   return ::WSAPoll(fds, nfds, timeout);
 }
 #else
-int Client::sys_poll(pollfd *fds, nfds_t nfds, int timeout) noexcept {
+int Client::sys_poll(pollfd *fds, nfds_t nfds, int timeout) const noexcept {
   return ::poll(fds, nfds, timeout);
 }
 #endif

--- a/libndt_test.cpp
+++ b/libndt_test.cpp
@@ -311,7 +311,7 @@ class FailNetxRecvn : public libndt::Client {
  public:
   using libndt::Client::Client;
   libndt::Err netx_recvn(libndt::Socket, void *,
-                         libndt::Size) noexcept override {
+                         libndt::Size) const noexcept override {
     return libndt::Err::io_error;
   }
 };
@@ -325,7 +325,7 @@ class NetxRecvnEof : public libndt::Client {
  public:
   using libndt::Client::Client;
   libndt::Err netx_recvn(libndt::Socket, void *,
-                         libndt::Size) noexcept override {
+                         libndt::Size) const noexcept override {
     return libndt::Err::eof;
   }
 };
@@ -339,7 +339,7 @@ class NetxRecvnInvalidKickoff : public libndt::Client {
  public:
   using libndt::Client::Client;
   libndt::Err netx_recvn(  //
-      libndt::Socket, void *buf, libndt::Size siz) noexcept override {
+      libndt::Socket, void *buf, libndt::Size siz) const noexcept override {
     REQUIRE(buf != nullptr);
     REQUIRE(siz >= 1);
     for (libndt::Size i = 0; i < siz; ++i) {
@@ -591,7 +591,7 @@ class FailNetxSelectDuringDownload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_poll(std::vector<pollfd> *, int) noexcept override {
+  libndt::Err netx_poll(std::vector<pollfd> *, int) const noexcept override {
     return libndt::Err::io_error;
   }
 };
@@ -613,11 +613,11 @@ class FailRecvDuringDownload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_poll(std::vector<pollfd> *, int) noexcept override {
+  libndt::Err netx_poll(std::vector<pollfd> *, int) const noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recv_nonblocking(libndt::Socket, void *, libndt::Size,
-                                    libndt::Size *) noexcept override {
+                                    libndt::Size *) const noexcept override {
     return libndt::Err::invalid_argument;
   }
 };
@@ -639,11 +639,11 @@ class RecvEofDuringDownload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_poll(std::vector<pollfd> *, int) noexcept override {
+  libndt::Err netx_poll(std::vector<pollfd> *, int) const noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recv_nonblocking(libndt::Socket, void *, libndt::Size,
-                                    libndt::Size *) noexcept override {
+                                    libndt::Size *) const noexcept override {
     return libndt::Err::eof;
   }
 };
@@ -667,11 +667,11 @@ class FailMsgReadLegacyDuringDownload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_poll(std::vector<pollfd> *, int) noexcept override {
+  libndt::Err netx_poll(std::vector<pollfd> *, int) const noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recv_nonblocking(libndt::Socket, void *, libndt::Size,
-                                    libndt::Size *) noexcept override {
+                                    libndt::Size *) const noexcept override {
     return libndt::Err::eof;
   }
   bool msg_read_legacy(libndt::MsgType *, std::string *) noexcept override {
@@ -697,11 +697,11 @@ class RecvNonTestMsgDuringDownload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_poll(std::vector<pollfd> *, int) noexcept override {
+  libndt::Err netx_poll(std::vector<pollfd> *, int) const noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recv_nonblocking(libndt::Socket, void *, libndt::Size,
-                                    libndt::Size *) noexcept override {
+                                    libndt::Size *) const noexcept override {
     return libndt::Err::eof;
   }
   bool msg_read_legacy(libndt::MsgType *code, std::string *) noexcept override {
@@ -727,11 +727,11 @@ class FailMsgWriteDuringDownload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_poll(std::vector<pollfd> *, int) noexcept override {
+  libndt::Err netx_poll(std::vector<pollfd> *, int) const noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recv_nonblocking(libndt::Socket, void *, libndt::Size,
-                                    libndt::Size *) noexcept override {
+                                    libndt::Size *) const noexcept override {
     return libndt::Err::eof;
   }
   bool msg_read_legacy(libndt::MsgType *code, std::string *) noexcept override {
@@ -760,11 +760,11 @@ class FailMsgReadDuringDownload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_poll(std::vector<pollfd> *, int) noexcept override {
+  libndt::Err netx_poll(std::vector<pollfd> *, int) const noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recv_nonblocking(libndt::Socket, void *, libndt::Size,
-                                    libndt::Size *) noexcept override {
+                                    libndt::Size *) const noexcept override {
     return libndt::Err::eof;
   }
   bool msg_read_legacy(libndt::MsgType *code, std::string *) noexcept override {
@@ -796,11 +796,11 @@ class RecvNonTestOrLogoutMsgDuringDownload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_poll(std::vector<pollfd> *, int) noexcept override {
+  libndt::Err netx_poll(std::vector<pollfd> *, int) const noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recv_nonblocking(libndt::Socket, void *, libndt::Size,
-                                    libndt::Size *) noexcept override {
+                                    libndt::Size *) const noexcept override {
     return libndt::Err::eof;
   }
   bool msg_read_legacy(libndt::MsgType *code, std::string *) noexcept override {
@@ -833,11 +833,11 @@ class FailEmitResultDuringDownload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_poll(std::vector<pollfd> *, int) noexcept override {
+  libndt::Err netx_poll(std::vector<pollfd> *, int) const noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recv_nonblocking(libndt::Socket, void *, libndt::Size,
-                                    libndt::Size *) noexcept override {
+                                    libndt::Size *) const noexcept override {
     return libndt::Err::eof;
   }
   bool msg_read_legacy(libndt::MsgType *code, std::string *) noexcept override {
@@ -871,11 +871,11 @@ class TooManyTestMsgsDuringDownload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_poll(std::vector<pollfd> *, int) noexcept override {
+  libndt::Err netx_poll(std::vector<pollfd> *, int) const noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recv_nonblocking(libndt::Socket, void *, libndt::Size,
-                                    libndt::Size *) noexcept override {
+                                    libndt::Size *) const noexcept override {
     return libndt::Err::eof;
   }
   bool msg_read_legacy(libndt::MsgType *code, std::string *) noexcept override {
@@ -1026,11 +1026,11 @@ class FailSendDuringUpload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_poll(std::vector<pollfd> *, int) noexcept override {
+  libndt::Err netx_poll(std::vector<pollfd> *, int) const noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_send_nonblocking(libndt::Socket, const void *, libndt::Size,
-                                    libndt::Size *) noexcept override {
+                                    libndt::Size *) const noexcept override {
     return libndt::Err::io_error;
   }
 };
@@ -1059,11 +1059,11 @@ class FailMsgExpectDuringUpload : public libndt::Client {
     return libndt::Err::none;
   }
   bool msg_expect_empty(libndt::MsgType) noexcept override { return true; }
-  libndt::Err netx_poll(std::vector<pollfd> *, int) noexcept override {
+  libndt::Err netx_poll(std::vector<pollfd> *, int) const noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_send_nonblocking(libndt::Socket, const void *, libndt::Size,
-                                    libndt::Size *) noexcept override {
+                                    libndt::Size *) const noexcept override {
     return libndt::Err::io_error;
   }
   bool msg_expect(libndt::MsgType, std::string *) noexcept override {
@@ -1090,11 +1090,11 @@ class FailFinalMsgExpectEmptyDuringUpload : public libndt::Client {
   bool msg_expect_empty(libndt::MsgType code) noexcept override {
     return code != libndt::msg_test_finalize;
   }
-  libndt::Err netx_poll(std::vector<pollfd> *, int) noexcept override {
+  libndt::Err netx_poll(std::vector<pollfd> *, int) const noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_send_nonblocking(libndt::Socket, const void *, libndt::Size,
-                                    libndt::Size *) noexcept override {
+                                    libndt::Size *) const noexcept override {
     return libndt::Err::io_error;
   }
   bool msg_expect(libndt::MsgType, std::string *) noexcept override {
@@ -1231,7 +1231,7 @@ class FailNetxSendn : public libndt::Client {
  public:
   using libndt::Client::Client;
   libndt::Err netx_sendn(libndt::Socket, const void *,
-                         libndt::Size) noexcept override {
+                         libndt::Size) const noexcept override {
     return libndt::Err::io_error;
   }
 };
@@ -1250,7 +1250,7 @@ class FailLargeNetxSendn : public libndt::Client {
  public:
   using libndt::Client::Client;
   libndt::Err netx_sendn(libndt::Socket, const void *,
-                         libndt::Size siz) noexcept override {
+                         libndt::Size siz) const noexcept override {
     return siz == 3 ? libndt::Err::none : libndt::Err::io_error;
   }
 };
@@ -1441,7 +1441,7 @@ class FailLargeNetxRecvn : public libndt::Client {
  public:
   using libndt::Client::Client;
   libndt::Err netx_recvn(libndt::Socket, void *p,
-                         libndt::Size siz) noexcept override {
+                         libndt::Size siz) const noexcept override {
     if (siz == 3) {
       char *usablep = (char *)p;
       usablep[0] = libndt::msg_login;
@@ -1495,7 +1495,7 @@ class Maybesocks5hConnectFailFirstNetxSendn : public libndt::Client {
     return libndt::Err::none;
   }
   libndt::Err netx_sendn(libndt::Socket, const void *,
-                         libndt::Size) noexcept override {
+                         libndt::Size) const noexcept override {
     return libndt::Err::io_error;
   }
 };
@@ -1520,11 +1520,11 @@ class Maybesocks5hConnectFailFirstNetxRecvn : public libndt::Client {
     return libndt::Err::none;
   }
   libndt::Err netx_sendn(libndt::Socket, const void *,
-                         libndt::Size) noexcept override {
+                         libndt::Size) const noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recvn(libndt::Socket, void *,
-                         libndt::Size) noexcept override {
+                         libndt::Size) const noexcept override {
     return libndt::Err::io_error;
   }
 };
@@ -1549,11 +1549,11 @@ class Maybesocks5hConnectInvalidAuthResponseVersion : public libndt::Client {
     return libndt::Err::none;
   }
   libndt::Err netx_sendn(libndt::Socket, const void *,
-                         libndt::Size) noexcept override {
+                         libndt::Size) const noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recvn(libndt::Socket, void *buf,
-                         libndt::Size size) noexcept override {
+                         libndt::Size size) const noexcept override {
     assert(size == 2);
     (void)size;
     ((char *)buf)[0] = 4;  // unexpected
@@ -1582,11 +1582,11 @@ class Maybesocks5hConnectInvalidAuthResponseMethod : public libndt::Client {
     return libndt::Err::none;
   }
   libndt::Err netx_sendn(libndt::Socket, const void *,
-                         libndt::Size) noexcept override {
+                         libndt::Size) const noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recvn(libndt::Socket, void *buf,
-                         libndt::Size size) noexcept override {
+                         libndt::Size size) const noexcept override {
     assert(size == 2);
     (void)size;
     ((char *)buf)[0] = 5;
@@ -1615,11 +1615,11 @@ class Maybesocks5hConnectInitialHandshakeOkay : public libndt::Client {
     return libndt::Err::none;
   }
   libndt::Err netx_sendn(libndt::Socket, const void *,
-                         libndt::Size) noexcept override {
+                         libndt::Size) const noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recvn(libndt::Socket, void *buf,
-                         libndt::Size size) noexcept override {
+                         libndt::Size size) const noexcept override {
     assert(size == 2);
     (void)size;
     ((char *)buf)[0] = 5;
@@ -1659,11 +1659,11 @@ class Maybesocks5hConnectFailSecondNetxSendn : public libndt::Client {
     return libndt::Err::none;
   }
   libndt::Err netx_sendn(libndt::Socket, const void *,
-                         libndt::Size size) noexcept override {
+                         libndt::Size size) const noexcept override {
     return size == 3 ? libndt::Err::none : libndt::Err::io_error;
   }
   libndt::Err netx_recvn(libndt::Socket, void *buf,
-                         libndt::Size size) noexcept override {
+                         libndt::Size size) const noexcept override {
     assert(size == 2);
     (void)size;
     ((char *)buf)[0] = 5;
@@ -1692,11 +1692,11 @@ class Maybesocks5hConnectFailSecondNetxRecvn : public libndt::Client {
     return libndt::Err::none;
   }
   libndt::Err netx_sendn(libndt::Socket, const void *,
-                         libndt::Size) noexcept override {
+                         libndt::Size) const noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recvn(libndt::Socket, void *buf,
-                         libndt::Size size) noexcept override {
+                         libndt::Size size) const noexcept override {
     if (size == 2) {
       ((char *)buf)[0] = 5;
       ((char *)buf)[1] = 0;
@@ -1726,11 +1726,11 @@ class Maybesocks5hConnectInvalidSecondVersion : public libndt::Client {
     return libndt::Err::none;
   }
   libndt::Err netx_sendn(libndt::Socket, const void *,
-                         libndt::Size) noexcept override {
+                         libndt::Size) const noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recvn(libndt::Socket, void *buf,
-                         libndt::Size size) noexcept override {
+                         libndt::Size size) const noexcept override {
     if (size == 2) {
       ((char *)buf)[0] = 5;
       ((char *)buf)[1] = 0;
@@ -1765,11 +1765,11 @@ class Maybesocks5hConnectErrorResult : public libndt::Client {
     return libndt::Err::none;
   }
   libndt::Err netx_sendn(libndt::Socket, const void *,
-                         libndt::Size) noexcept override {
+                         libndt::Size) const noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recvn(libndt::Socket, void *buf,
-                         libndt::Size size) noexcept override {
+                         libndt::Size size) const noexcept override {
     if (size == 2) {
       ((char *)buf)[0] = 5;
       ((char *)buf)[1] = 0;
@@ -1804,11 +1804,11 @@ class Maybesocks5hConnectInvalidReserved : public libndt::Client {
     return libndt::Err::none;
   }
   libndt::Err netx_sendn(libndt::Socket, const void *,
-                         libndt::Size) noexcept override {
+                         libndt::Size) const noexcept override {
     return libndt::Err::none;
   }
   libndt::Err netx_recvn(libndt::Socket, void *buf,
-                         libndt::Size size) noexcept override {
+                         libndt::Size size) const noexcept override {
     if (size == 2) {
       ((char *)buf)[0] = 5;
       ((char *)buf)[1] = 0;
@@ -1844,20 +1844,20 @@ class Maybesocks5hConnectFailAddressNetxRecvn : public libndt::Client {
     return libndt::Err::none;
   }
   libndt::Err netx_sendn(libndt::Socket, const void *,
-                         libndt::Size) noexcept override {
+                         libndt::Size) const noexcept override {
     return libndt::Err::none;
   }
   uint8_t type = 0;
-  bool seen = false;
+  std::shared_ptr<bool> seen = std::make_shared<bool>(false);
   libndt::Err netx_recvn(libndt::Socket, void *buf,
-                         libndt::Size size) noexcept override {
+                         libndt::Size size) const noexcept override {
     if (size == 2) {
       ((char *)buf)[0] = 5;
       ((char *)buf)[1] = 0;
       return libndt::Err::none;
     }
     if (size == 4 && !seen) {
-      seen = true;  // use flag because IPv4 is also 4 bytes
+      *seen = true;  // use flag because IPv4 is also 4 bytes
       assert(type != 0);
       ((char *)buf)[0] = 5;
       ((char *)buf)[1] = 0;
@@ -1915,17 +1915,18 @@ class Maybesocks5hConnectWithArray : public libndt::Client {
     return libndt::Err::none;
   }
   libndt::Err netx_sendn(libndt::Socket, const void *,
-                         libndt::Size) noexcept override {
+                         libndt::Size) const noexcept override {
     return libndt::Err::none;
   }
-  std::deque<std::string> array;
+  std::shared_ptr<std::deque<std::string>> array = std::make_shared<
+      std::deque<std::string>>();
   libndt::Err netx_recvn(libndt::Socket, void *buf,
-                         libndt::Size size) noexcept override {
-    if (!array.empty() && size == array[0].size()) {
-      for (size_t idx = 0; idx < array[0].size(); ++idx) {
-        ((char *)buf)[idx] = array[0][idx];
+                         libndt::Size size) const noexcept override {
+    if (!array->empty() && size == (*array)[0].size()) {
+      for (size_t idx = 0; idx < (*array)[0].size(); ++idx) {
+        ((char *)buf)[idx] = (*array)[0][idx];
       }
-      array.pop_front();
+      array->pop_front();
       return libndt::Err::none;
     }
     return libndt::Err::io_error;
@@ -1938,7 +1939,7 @@ TEST_CASE(
   libndt::Settings settings;
   settings.socks5h_port = "9050";
   Maybesocks5hConnectWithArray client{settings};
-  client.array = {
+  *client.array = {
       std::string{"\5\0", 2},
       std::string{"\5\0\0\3", 4},
   };
@@ -1953,7 +1954,7 @@ TEST_CASE(
   libndt::Settings settings;
   settings.socks5h_port = "9050";
   Maybesocks5hConnectWithArray client{settings};
-  client.array = {
+  *client.array = {
       std::string{"\5\0", 2},
       std::string{"\5\0\0\3", 4},
       std::string{"\7", 1},
@@ -1969,7 +1970,7 @@ TEST_CASE(
   libndt::Settings settings;
   settings.socks5h_port = "9050";
   Maybesocks5hConnectWithArray client{settings};
-  client.array = {
+  *client.array = {
       std::string{"\5\0", 2},
       std::string{"\5\0\0\3", 4},
       std::string{"\7", 1},
@@ -1984,7 +1985,7 @@ TEST_CASE("Client::netx_maybesocks5h_dial() works with IPv4 (mocked)") {
   libndt::Settings settings;
   settings.socks5h_port = "9050";
   Maybesocks5hConnectWithArray client{settings};
-  client.array = {
+  *client.array = {
       std::string{"\5\0", 2},
       std::string{"\5\0\0\1", 4},
       std::string{"\0\0\0\0", 4},
@@ -1999,7 +2000,7 @@ TEST_CASE("Client::netx_maybesocks5h_dial() works with IPv6 (mocked)") {
   libndt::Settings settings;
   settings.socks5h_port = "9050";
   Maybesocks5hConnectWithArray client{settings};
-  client.array = {
+  *client.array = {
       std::string{"\5\0", 2},
       std::string{"\5\0\0\4", 4},
       std::string{"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 16},
@@ -2174,7 +2175,7 @@ class FailSocketConnectTimeout : public libndt::Client {
     sys_set_last_error(OS_EINPROGRESS);
     return -1;
   }
-  libndt::Err netx_poll(std::vector<pollfd> *, int) noexcept override {
+  libndt::Err netx_poll(std::vector<pollfd> *, int) const noexcept override {
     return libndt::Err::timed_out;
   }
 };
@@ -2193,7 +2194,8 @@ class FailSocketConnectGetsockoptError : public libndt::Client {
     sys_set_last_error(OS_EINPROGRESS);
     return -1;
   }
-  libndt::Err netx_poll(std::vector<pollfd> *pfds, int) noexcept override {
+  libndt::Err netx_poll(
+      std::vector<pollfd> *pfds, int) const noexcept override {
     for (auto &fd : *pfds) {
       fd.revents = fd.events;
     }
@@ -2221,7 +2223,8 @@ class FailSocketConnectSocketError : public libndt::Client {
     sys_set_last_error(OS_EINPROGRESS);
     return -1;
   }
-  libndt::Err netx_poll(std::vector<pollfd> *pfds, int) noexcept override {
+  libndt::Err netx_poll(
+      std::vector<pollfd> *pfds, int) const noexcept override {
     for (auto &fd : *pfds) {
       fd.revents = fd.events;
     }
@@ -2272,7 +2275,7 @@ class FailNetxRecv : public libndt::Client {
  public:
   using libndt::Client::Client;
   libndt::Err netx_recv(libndt::Socket, void *, libndt::Size,
-                        libndt::Size *) noexcept override {
+                        libndt::Size *) const noexcept override {
     return libndt::Err::invalid_argument;
   }
 };
@@ -2288,7 +2291,7 @@ class RecvEof : public libndt::Client {
  public:
   using libndt::Client::Client;
   libndt::Ssize sys_recv(libndt::Socket, void *,
-                         libndt::Size) noexcept override {
+                         libndt::Size) const noexcept override {
     return 0;
   }
 };
@@ -2305,7 +2308,7 @@ class PartialNetxRecvAndThenError : public libndt::Client {
   static constexpr libndt::Size amount = 11;
   static constexpr libndt::Size good_amount = 3;
   libndt::Err netx_recv(libndt::Socket, void *buf, libndt::Size size,
-                        libndt::Size *rv) noexcept override {
+                        libndt::Size *rv) const noexcept override {
     if (size == amount) {
       assert(size >= good_amount);
       for (size_t i = 0; i < good_amount; ++i) {
@@ -2343,7 +2346,7 @@ class PartialRecvAndThenEof : public libndt::Client {
   static constexpr libndt::Size amount = 7;
   static constexpr libndt::Size good_amount = 5;
   libndt::Ssize sys_recv(libndt::Socket, void *buf,
-                         libndt::Size size) noexcept override {
+                         libndt::Size size) const noexcept override {
     if (size == amount) {
       assert(size >= good_amount);
       for (size_t i = 0; i < good_amount; ++i) {
@@ -2396,7 +2399,7 @@ class FailSend : public libndt::Client {
  public:
   using libndt::Client::Client;
   libndt::Ssize sys_send(libndt::Socket, const void *,
-                         libndt::Size) noexcept override {
+                         libndt::Size) const noexcept override {
     sys_set_last_error(OS_EINVAL);
     return -1;
   }
@@ -2414,7 +2417,7 @@ class SendEof : public libndt::Client {
  public:
   using libndt::Client::Client;
   libndt::Ssize sys_send(libndt::Socket, const void *,
-                         libndt::Size) noexcept override {
+                         libndt::Size) const noexcept override {
     return 0;
   }
 };
@@ -2430,12 +2433,12 @@ class PartialSendAndThenError : public libndt::Client {
   using libndt::Client::Client;
   static constexpr libndt::Size amount = 11;
   static constexpr libndt::Size good_amount = 3;
-  libndt::Size successful = 0;
+  std::shared_ptr<libndt::Size> successful = std::make_shared<libndt::Size>(0);
   libndt::Ssize sys_send(libndt::Socket, const void *,
-                         libndt::Size size) noexcept override {
+                         libndt::Size size) const noexcept override {
     if (size == amount) {
       assert(size >= good_amount);
-      successful += good_amount;
+      *successful += good_amount;
       return good_amount;
     }
     sys_set_last_error(OS_EINVAL);
@@ -2453,7 +2456,7 @@ TEST_CASE("Client::send() deals with partial Client::send() and then error") {
   //
   // Usage of `exp` is required to make clang compile (unclear to me why).
   auto exp = PartialSendAndThenError::good_amount;
-  REQUIRE(client.successful == exp);
+  REQUIRE((*client.successful) == exp);
 }
 
 // See above comment regarding likelihood of send returning EOF (i.e. zero)
@@ -2462,12 +2465,12 @@ class PartialSendAndThenEof : public libndt::Client {
   using libndt::Client::Client;
   static constexpr libndt::Size amount = 7;
   static constexpr libndt::Size good_amount = 5;
-  libndt::Size successful = 0;
+  std::shared_ptr<libndt::Size> successful = std::make_shared<libndt::Size>(0);
   libndt::Ssize sys_send(libndt::Socket, const void *,
-                         libndt::Size size) noexcept override {
+                         libndt::Size size) const noexcept override {
     if (size == amount) {
       assert(size >= good_amount);
-      successful += good_amount;
+      *successful += good_amount;
       return good_amount;
     }
     return 0;
@@ -2484,7 +2487,7 @@ TEST_CASE(
   //
   // Usage of `exp` is required to make clang compile (unclear to me why).
   auto exp = PartialSendAndThenEof::good_amount;
-  REQUIRE(client.successful == exp);
+  REQUIRE((*client.successful) == exp);
 }
 
 // Client::netx_resolve() tests
@@ -2613,9 +2616,9 @@ TEST_CASE(
 class InterruptPoll : public libndt::Client {
  public:
   using libndt::Client::Client;
-  unsigned int count = 0;
-  int sys_poll(pollfd *, nfds_t, int) noexcept override {
-    if (count++ == 0) {
+  std::shared_ptr<unsigned int> count = std::make_shared<unsigned int>();
+  int sys_poll(pollfd *, nfds_t, int) const noexcept override {
+    if ((*count)++ == 0) {
       sys_set_last_error(EINTR);
     } else {
       sys_set_last_error(EIO);
@@ -2634,7 +2637,7 @@ TEST_CASE("Client::netx_poll() deals with EINTR") {
   InterruptPoll client;
   constexpr int timeout = 100;
   REQUIRE(client.netx_poll(&pfds, timeout) == libndt::Err::io_error);
-  REQUIRE(client.count == 2);
+  REQUIRE(*client.count == 2);
 }
 
 #endif  // !_WIN32
@@ -2643,9 +2646,9 @@ class TimeoutPoll : public libndt::Client {
  public:
   using libndt::Client::Client;
 #ifdef _WIN32
-  int sys_poll(LPWSAPOLLFD, ULONG, INT) noexcept override
+  int sys_poll(LPWSAPOLLFD, ULONG, INT) const noexcept override
 #else
-  int sys_poll(pollfd *, nfds_t, int) noexcept override
+  int sys_poll(pollfd *, nfds_t, int) const noexcept override
 #endif
   {
     return 0;

--- a/libndt_test.cpp
+++ b/libndt_test.cpp
@@ -1856,7 +1856,7 @@ class Maybesocks5hConnectFailAddressNetxRecvn : public libndt::Client {
       ((char *)buf)[1] = 0;
       return libndt::Err::none;
     }
-    if (size == 4 && !seen) {
+    if (size == 4 && !*seen) {
       *seen = true;  // use flag because IPv4 is also 4 bytes
       assert(type != 0);
       ((char *)buf)[0] = 5;


### PR DESCRIPTION
Pass to such threads a const pointer and hence guarantee that they cannot make changes to the internals of a Client while they are running. Closes #69.