### PR TITLE
Output web100/summary as JSON and provide performance info

### DIFF
--- a/libndt-client.cpp
+++ b/libndt-client.cpp
@@ -36,9 +36,16 @@ void BatchClient::on_result(std::string, std::string,  std::string value) {
   std::cout << value << std::endl;
 }
 // on_performance is overridded to hide the user-friendly output messages.
-void BatchClient::on_performance(libndt::NettestFlags, uint8_t, double, double,
-                                 double) {
-  /* NOTHING */
+void BatchClient::on_performance(libndt::NettestFlags tid, uint8_t nflows,
+                            double measured_bytes,
+                            double elapsed_time, double) {
+  nlohmann::json performance;
+  performance["ElapsedTime"] = elapsed_time;
+  performance["NumFlows"] = nflows;
+  performance["TestId"] = (int)tid;
+  performance["Speed"] = libndt::format_speed_from_kbits(measured_bytes,
+                                                         elapsed_time);
+  std::cout << performance.dump() << std::endl;
 }
 
 

--- a/libndt.hpp
+++ b/libndt.hpp
@@ -849,7 +849,7 @@ class Client {
   XX(tcpi_rwnd_limited, TcpiRwndLimited) \
   XX(tcpi_sndbuf_limited, TcpiSndbufLimited) \
   XX(tcpi_bytes_sent, TcpiBytesSent) \
-  XX(tcpi_bytes_retrans, TcpiBytesRetrans) \
+  XX(tcpi_bytes_retrans, TcpiBytesRetrans)
 #endif // __linux__
 // Strtonum
 // ````````

--- a/libndt.hpp
+++ b/libndt.hpp
@@ -839,59 +839,17 @@ class Client {
 #ifdef __linux__
 #include <linux/tcp.h>
 #define NDT7_ENUM_TCP_INFO \
-  XX(tcpi_state, TcpiState) \
-  XX(tcpi_ca_state, TcpiCaState) \
-  XX(tcpi_retransmits, TcpiRetransmits) \
-  XX(tcpi_probes, TcpiProbes) \
-  XX(tcpi_backoff, TcpiBackoff) \
-  XX(tcpi_options, TcpiOptions) \
-  XX(tcpi_snd_wscale, TcpiSndWscale) \
-  XX(tcpi_rcv_wscale, TcpiRcvWscale) \
-  XX(tcpi_delivery_rate_app_limited, TcpiDeliveryRateAppLimited) \
-  XX(tcpi_rto, TcpiRto) \
-  XX(tcpi_ato, TcpiAto) \
-  XX(tcpi_snd_mss, TcpiSndMss) \
-  XX(tcpi_rcv_mss, TcpiRcvMss) \
-  XX(tcpi_unacked, TcpiUnacked) \
-  XX(tcpi_sacked, TcpiSacked) \
-  XX(tcpi_lost, TcpiLost) \
-  XX(tcpi_retrans, TcpiRetrans) \
-  XX(tcpi_fackets, TcpiFackets) \
-  XX(tcpi_last_data_sent, TcpiLastDataSent) \
-  XX(tcpi_last_ack_sent, TcpiLastAckSent) \
-  XX(tcpi_last_data_recv, TcpiLastDataRecv) \
-  XX(tcpi_last_ack_recv, TcpiLastAckRecv) \
-  XX(tcpi_pmtu, TcpiPmtu) \
-  XX(tcpi_rcv_ssthresh, TcpiRcvSsthresh) \
   XX(tcpi_rtt, TcpiRtt) \
   XX(tcpi_rttvar, TcpiRttvar) \
-  XX(tcpi_snd_ssthresh, TcpiSndSsthresh) \
-  XX(tcpi_snd_cwnd, TcpiSndCwnd) \
-  XX(tcpi_advmss, TcpiAdvmss) \
   XX(tcpi_reordering, TcpiReordering) \
-  XX(tcpi_rcv_rtt, TcpiRcvRtt) \
-  XX(tcpi_rcv_space, TcpiRcvSpace) \
-  XX(tcpi_total_retrans, TcpiTotalRetrans) \
-  XX(tcpi_pacing_rate, TcpiPacingRate) \
-  XX(tcpi_max_pacing_rate, TcpiMaxPacingRate) \
   XX(tcpi_bytes_acked, TcpiBytesAcked) \
   XX(tcpi_bytes_received, TcpiBytesReceived) \
-  XX(tcpi_segs_out, TcpiSegsOut) \
-  XX(tcpi_segs_in, TcpiSegsIn) \
-  XX(tcpi_notsent_bytes, TcpiNotsentBytes) \
   XX(tcpi_min_rtt, TcpiMinRtt) \
-  XX(tcpi_data_segs_in, TcpiDataSegsIn) \
-  XX(tcpi_data_segs_out, TcpiDataSegsOut) \
-  XX(tcpi_delivery_rate, TcpiDeliveryRate) \
   XX(tcpi_busy_time, TcpiBusyTime) \
   XX(tcpi_rwnd_limited, TcpiRwndLimited) \
   XX(tcpi_sndbuf_limited, TcpiSndbufLimited) \
-  XX(tcpi_delivered, TcpiDelivered) \
-  XX(tcpi_delivered_ce, TcpiDeliveredCe) \
   XX(tcpi_bytes_sent, TcpiBytesSent) \
   XX(tcpi_bytes_retrans, TcpiBytesRetrans) \
-  XX(tcpi_dsack_dups, TcpiDsackDups) \
-  XX(tcpi_reord_seen, TcpiReordSeen)
 #endif // __linux__
 // Strtonum
 // ````````

--- a/libndt.hpp
+++ b/libndt.hpp
@@ -1144,7 +1144,7 @@ static std::string trim(std::string s) noexcept {
   return s;
 }
 
-static bool emit_result(Client *client, std::string scope,
+static bool parse_result(Client *client, nlohmann::json &summary,
                         std::string message) noexcept {
   std::stringstream ss_line{message};
   std::string line;
@@ -1157,10 +1157,9 @@ static bool emit_result(Client *client, std::string scope,
     }
     if (keyval.size() != 2) {
       LIBNDT_EMIT_WARNING_EX(client, "incorrectly formatted summary message: " << message);
-      return false;
+      continue;
     }
-    client->on_result(scope, trim(std::move(keyval[0])),
-                      trim(std::move(keyval[1])));
+    summary[trim(keyval[0])] = trim(keyval[1]);
   }
   return true;
 }
@@ -1531,6 +1530,9 @@ bool Client::run_tests() noexcept {
 }
 
 bool Client::recv_results_and_logout() noexcept {
+  // Read summary from the server and put it into a JSON object.
+  nlohmann::json summary;
+
   for (auto i = 0; i < max_loops; ++i) {  // don't loop forever
     std::string message;
     MsgType code = MsgType{0};
@@ -1542,13 +1544,15 @@ bool Client::recv_results_and_logout() noexcept {
       return false;
     }
     if (code == msg_logout) {
+      this->on_result("summary", "summary", std::move(summary.dump()));
       return true;
     }
-    if (!emit_result(this, "summary", std::move(message))) {
-      // NOTHING: apparently ndt-cloud returns a free text message in this
-      // case and the warning has already been printed by emit_result(). We
-      // used to fail here but probably it's more robust just to warn.
-    }
+
+    if (!parse_result(this, summary, std::move(message))) {
+        // NOTHING: apparently ndt-cloud returns a free text message in this
+        // case and the warning has already been printed by emit_result(). We
+        // used to fail here but probably it's more robust just to warn.
+      }
   }
   LIBNDT_EMIT_WARNING("recv_results_and_logout: too many msg_results messages");
   return false;  // Too many loops
@@ -1709,6 +1713,7 @@ bool Client::run_download() noexcept {
   }
 
   LIBNDT_EMIT_INFO("reading summary web100 variables");
+  nlohmann::json web100;
   for (auto i = 0; i < max_loops; ++i) {  // don't loop forever
     std::string message;
     MsgType code = MsgType{0};
@@ -1720,9 +1725,10 @@ bool Client::run_download() noexcept {
       return false;
     }
     if (code == msg_test_finalize) {
+      this->on_result("web100", "web100", std::move(web100.dump()));
       return true;
     }
-    if (!emit_result(this, "web100", std::move(message))) {
+    if (!parse_result(this, web100, std::move(message))) {
       // NOTHING: warning already printed by emit_result() and failing the whole
       // test - rather than warning - because of an incorrect data format is
       // probably being too strict in this context. So just keep going.

--- a/libndt.hpp
+++ b/libndt.hpp
@@ -839,17 +839,59 @@ class Client {
 #ifdef __linux__
 #include <linux/tcp.h>
 #define NDT7_ENUM_TCP_INFO \
+  XX(tcpi_state, TcpiState) \
+  XX(tcpi_ca_state, TcpiCaState) \
+  XX(tcpi_retransmits, TcpiRetransmits) \
+  XX(tcpi_probes, TcpiProbes) \
+  XX(tcpi_backoff, TcpiBackoff) \
+  XX(tcpi_options, TcpiOptions) \
+  XX(tcpi_snd_wscale, TcpiSndWscale) \
+  XX(tcpi_rcv_wscale, TcpiRcvWscale) \
+  XX(tcpi_delivery_rate_app_limited, TcpiDeliveryRateAppLimited) \
+  XX(tcpi_rto, TcpiRto) \
+  XX(tcpi_ato, TcpiAto) \
+  XX(tcpi_snd_mss, TcpiSndMss) \
+  XX(tcpi_rcv_mss, TcpiRcvMss) \
+  XX(tcpi_unacked, TcpiUnacked) \
+  XX(tcpi_sacked, TcpiSacked) \
+  XX(tcpi_lost, TcpiLost) \
+  XX(tcpi_retrans, TcpiRetrans) \
+  XX(tcpi_fackets, TcpiFackets) \
+  XX(tcpi_last_data_sent, TcpiLastDataSent) \
+  XX(tcpi_last_ack_sent, TcpiLastAckSent) \
+  XX(tcpi_last_data_recv, TcpiLastDataRecv) \
+  XX(tcpi_last_ack_recv, TcpiLastAckRecv) \
+  XX(tcpi_pmtu, TcpiPmtu) \
+  XX(tcpi_rcv_ssthresh, TcpiRcvSsthresh) \
   XX(tcpi_rtt, TcpiRtt) \
   XX(tcpi_rttvar, TcpiRttvar) \
+  XX(tcpi_snd_ssthresh, TcpiSndSsthresh) \
+  XX(tcpi_snd_cwnd, TcpiSndCwnd) \
+  XX(tcpi_advmss, TcpiAdvmss) \
   XX(tcpi_reordering, TcpiReordering) \
+  XX(tcpi_rcv_rtt, TcpiRcvRtt) \
+  XX(tcpi_rcv_space, TcpiRcvSpace) \
+  XX(tcpi_total_retrans, TcpiTotalRetrans) \
+  XX(tcpi_pacing_rate, TcpiPacingRate) \
+  XX(tcpi_max_pacing_rate, TcpiMaxPacingRate) \
   XX(tcpi_bytes_acked, TcpiBytesAcked) \
   XX(tcpi_bytes_received, TcpiBytesReceived) \
+  XX(tcpi_segs_out, TcpiSegsOut) \
+  XX(tcpi_segs_in, TcpiSegsIn) \
+  XX(tcpi_notsent_bytes, TcpiNotsentBytes) \
   XX(tcpi_min_rtt, TcpiMinRtt) \
+  XX(tcpi_data_segs_in, TcpiDataSegsIn) \
+  XX(tcpi_data_segs_out, TcpiDataSegsOut) \
+  XX(tcpi_delivery_rate, TcpiDeliveryRate) \
   XX(tcpi_busy_time, TcpiBusyTime) \
   XX(tcpi_rwnd_limited, TcpiRwndLimited) \
   XX(tcpi_sndbuf_limited, TcpiSndbufLimited) \
+  XX(tcpi_delivered, TcpiDelivered) \
+  XX(tcpi_delivered_ce, TcpiDeliveredCe) \
   XX(tcpi_bytes_sent, TcpiBytesSent) \
-  XX(tcpi_bytes_retrans, TcpiBytesRetrans)
+  XX(tcpi_bytes_retrans, TcpiBytesRetrans) \
+  XX(tcpi_dsack_dups, TcpiDsackDups) \
+  XX(tcpi_reord_seen, TcpiReordSeen)
 #endif // __linux__
 // Strtonum
 // ````````

--- a/libndt.hpp
+++ b/libndt.hpp
@@ -1544,7 +1544,7 @@ bool Client::recv_results_and_logout() noexcept {
       return false;
     }
     if (code == msg_logout) {
-      this->on_result("summary", "summary", std::move(summary.dump()));
+      this->on_result("summary", "summary", summary.dump());
       return true;
     }
 
@@ -1725,7 +1725,7 @@ bool Client::run_download() noexcept {
       return false;
     }
     if (code == msg_test_finalize) {
-      this->on_result("web100", "web100", std::move(web100.dump()));
+      this->on_result("web100", "web100", web100.dump());
       return true;
     }
     if (!parse_result(this, web100, std::move(message))) {


### PR DESCRIPTION
This PR groups the web100 and summary values coming from the server at the end of an NDT test together into two JSON objects, then prints them. This is so that the behavior of NDT and ndt7 are as similar as possible.

Additionally, JSON-formatted performance data is printed during the tests when `-batch` is used.

Closes https://github.com/measurement-kit/libndt/issues/137.