### PR TITLE
Add additional fields to ndt7's summary JSON

### DIFF
--- a/api.hpp
+++ b/api.hpp
@@ -751,7 +751,15 @@ class Client {
   };
 
   SummaryData summary_;
+
+  // NDT web100 summary data.
   nlohmann::json web100;
+
+  // ndt7 Measurement object.
+  nlohmann::json measurement_;
+
+  // ndt7 ConnectionInfo object.
+  nlohmann::json connection_info_;
 
  private:
   class Winsock {

--- a/impl.hpp
+++ b/impl.hpp
@@ -1173,11 +1173,14 @@ bool Client::ndt7_download() noexcept {
         std::string sinfo{(const char *)buff.get(), (size_t)count};
         // Try parsing the received message as JSON.
         try {
-          nlohmann::json appinfo = nlohmann::json::parse(sinfo);
+          measurement_ = nlohmann::json::parse(sinfo);
+          if (measurement_.find("ConnectionInfo") != measurement_.end()) {
+            connection_info_ = measurement_["ConnectionInfo"];
+          }
 
           // Calculate retransmission rate (BytesRetrans / BytesSent).
           try {
-            nlohmann::json tcpinfo_json = appinfo["TCPInfo"];
+            nlohmann::json tcpinfo_json = measurement_["TCPInfo"];
             double bytes_retrans = (double) tcpinfo_json["BytesRetrans"].get<int64_t>();
             double bytes_sent = (double) tcpinfo_json["BytesSent"].get<int64_t>();
             summary_.download_retrans = (bytes_sent != 0.0) ? bytes_retrans / bytes_sent : 0.0;

--- a/impl.hpp
+++ b/impl.hpp
@@ -1174,7 +1174,7 @@ bool Client::ndt7_download() noexcept {
         // Try parsing the received message as JSON.
         try {
           measurement_ = nlohmann::json::parse(sinfo);
-          if (measurement_.find("ConnectionInfo") != measurement_.end()) {
+          if (measurement_.contains("ConnectionInfo")) {
             connection_info_ = measurement_["ConnectionInfo"];
           }
 

--- a/libndt-client.cpp
+++ b/libndt-client.cpp
@@ -58,7 +58,16 @@ void BatchClient::summary() noexcept {
     nlohmann::json download;
     download["Speed"] = summary_.download_speed;
     download["Retransmission"] = summary_.download_retrans;
-    download["Web100"] = web100;
+
+    if (web100 != nullptr) {
+      download["Web100"] = web100;
+    }
+
+    if (measurement_ != nullptr) {
+      download["ConnectionInfo"] = connection_info_;
+      download["LastMeasurement"] = measurement_;
+    }
+
     summary["Download"] = download;
     summary["Latency"] = summary_.min_rtt;
   }


### PR DESCRIPTION
This PR adds new fields to ndt7's JSON summary. Specifically:
- `ConnectionInfo`, which is saved when received from the server
- `LastMeasurement`, which is the last `Measurement` object received (as defined [here](https://github.com/m-lab/ndt-server/blob/master/spec/ndt7-protocol.md#measurement-message))